### PR TITLE
Allow defining and external location for the system installation and use it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ FLATPAK_BINDIR=$(bindir)
 AM_CPPFLAGS =							\
 	-DFLATPAK_BINDIR=\"$(FLATPAK_BINDIR)\"			\
 	-DFLATPAK_SYSTEMDIR=\"$(SYSTEM_INSTALL_DIR)\"		\
+	-DFLATPAK_EXTERNALDIR=\"$(EXTERNAL_INSTALL_DIR)\"	\
 	-DFLATPAK_CONFIGDIR=\"$(sysconfdir)/flatpak\"		\
 	-DFLATPAK_BASEDIR=\"$(pkgdatadir)\"			\
 	-DFLATPAK_TRIGGERDIR=\"$(pkgdatadir)/triggers\"		\

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -186,6 +186,15 @@ flatpak_deploy_new (GFile *dir, GKeyFile *metadata)
   return deploy;
 }
 
+static gboolean
+is_valid_external_location (const char *path)
+{
+  if (path == NULL || !g_path_is_absolute (path))
+    return FALSE;
+
+  return g_file_test (path, G_FILE_TEST_IS_DIR);
+}
+
 GFile *
 flatpak_get_system_base_dir_location (void)
 {
@@ -197,6 +206,8 @@ flatpak_get_system_base_dir_location (void)
       const char *system_dir = g_getenv ("FLATPAK_SYSTEM_DIR");
       if (system_dir != NULL)
         setup_value = (gsize)system_dir;
+      else if (is_valid_external_location (FLATPAK_EXTERNALDIR))
+        setup_value = (gsize)FLATPAK_EXTERNALDIR;
       else
         setup_value = (gsize)FLATPAK_SYSTEMDIR;
       g_once_init_leave (&path, setup_value);

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,14 @@ AC_ARG_WITH(system-install-dir,
 SYSTEM_INSTALL_DIR=$with_system_install_dir
 AC_SUBST(SYSTEM_INSTALL_DIR)
 
+AC_ARG_WITH(external-install-dir,
+           [AS_HELP_STRING([--with-external-install-dir=DIR],
+                           [Location of the external installation [LOCALSTATEDIR/endless-extra/flatpak]])],
+           [],
+           [with_external_install_dir='$(localstatedir)/endless-extra/flatpak'])
+EXTERNAL_INSTALL_DIR=$with_external_install_dir
+AC_SUBST(EXTERNAL_INSTALL_DIR)
+
 dnl This only checks for the header, not the library.
 AC_ARG_WITH([dwarf-header],
             [AS_HELP_STRING([--with-dwarf-header],


### PR DESCRIPTION
This is needed as a first step to having apps installed both in the system
directory and an external location, even though for now is just one or another
but not both.

This commit defines the --with-external-install-dir configuration parameter
that allows specifying a path which is considered at runtime: if it exists,
that one will be used, otherwise the default system directory will be picked.

https://phabricator.endlessm.com/T12030