### PR TITLE
Use /var/endless-extra/flatpak as external directory for system installation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,6 +21,7 @@ override_dh_auto_configure:
 		--with-privileged-group=sudo \
 		--with-system-bubblewrap=/usr/bin/bwrap \
 		--with-systemdsystemunitdir=/lib/systemd/system \
+		--with-external-install-dir=/var/endless-extra/flatpak \
 		$(NULL)
 
 override_dh_install:


### PR DESCRIPTION
This will make flatpak check on runtime for the existence of this directory,
and use it if it's there, falling back to /var/lib/flatpak otherwise.

https://phabricator.endlessm.com/T12030