### PR TITLE
Include the external installation directory in XDG_DATA_DIRS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,9 @@ DISTCLEANFILES += flatpak.sh
 
 flatpak.sh: profile/flatpak.sh.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+		-e "s|\@sysconfdir\@|$(sysconfdir)|" \
+		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
+		$< > $@
 
 envdir = $(datadir)/gdm/env.d
 env_DATA = flatpak.env
@@ -134,7 +136,9 @@ DISTCLEANFILES += flatpak.env
 
 flatpak.env: env.d/flatpak.env.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+		-e "s|\@sysconfdir\@|$(sysconfdir)|" \
+		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
+		$< > $@
 
 dbussnippetdir = $(systemduserunitdir)/dbus.service.d
 dbussnippet_DATA = flatpak.conf
@@ -143,7 +147,9 @@ DISTCLEANFILES += flatpak.conf
 
 flatpak.conf: dbus.service.d/flatpak.conf.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+		-e "s|\@sysconfdir\@|$(sysconfdir)|" \
+		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
+		$< > $@
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = flatpak.pc

--- a/dbus.service.d/flatpak.conf.in
+++ b/dbus.service.d/flatpak.conf.in
@@ -1,2 +1,2 @@
 [Service]
-Environment=XDG_DATA_DIRS=%h/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/
+Environment=XDG_DATA_DIRS=%h/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/

--- a/env.d/flatpak.env.in
+++ b/env.d/flatpak.env.in
@@ -1,1 +1,1 @@
-XDG_DATA_DIRS=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/
+XDG_DATA_DIRS=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/

--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -1,4 +1,4 @@
 # @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
 
-XDG_DATA_DIRS="${XDG_DATA_DIRS:-$HOME/.local/share/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/}"
+XDG_DATA_DIRS="${XDG_DATA_DIRS:-$HOME/.local/share/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/}"
 export XDG_DATA_DIRS


### PR DESCRIPTION
This will make it possible for the shell to discover exported files
installed under that location, so that the shell can find those flatpaks.

https://phabricator.endlessm.com/T13480