### PR TITLE
Temporary fix for knowledge applications in split disk layouts

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2566,6 +2566,19 @@ compute_permissions (GKeyFile *app_metadata,
 
   add_default_permissions (app_context);
 
+  /* FIXME: Temporary fix for EOS 3.0.4 so that we can ship the image on split
+   * disk layouts without having to rebundle all the knowledge apps, just to
+   * fix the subscription links, that will look into /var/endless-extra. */
+  if (g_file_test ("/var/endless-extra/flatpak", G_FILE_TEST_IS_DIR)) {
+    g_autofree char *app_name = g_key_file_get_string (app_metadata, "Application", "name", NULL);
+    if (app_name != NULL)
+      {
+        g_autofree char *extra_override = g_strdup_printf ("/var/endless-extra/flatpak/app/%s:ro", app_name);
+        if (flatpak_context_verify_filesystem (extra_override, NULL))
+          flatpak_context_add_filesystem (app_context, extra_override);
+      }
+  }
+
   if (!flatpak_context_load_metadata (app_context, runtime_metadata, error))
     return NULL;
 


### PR DESCRIPTION
The right solution would be to adapt the bundle manifests for each app,
but that would require rebundling all of them, but that's not feasible
for the incoming release so, as a temporary solution, we simply add an
extra default override in flatpak for each application, so that they
can automatically read /var/endless-extra/flatpak/app/APP_ID it they
are running in a split disk layout.

Note: this commit can safely be reverted once all the bundles have been
adapted to include the path for split disk layouts.

https://phabricator.endlessm.com/T13509