### PR TITLE
Support mixed (multilib/multiarch) binaries in Flatpaks

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -103,10 +103,12 @@ const char *flatpak_context_devices[] = {
 
 typedef enum {
   FLATPAK_CONTEXT_FEATURE_DEVEL        = 1 << 0,
+  FLATPAK_CONTEXT_FEATURE_MULTIARCH    = 1 << 1,
 } FlatpakContextFeatures;
 
 const char *flatpak_context_features[] = {
   "devel",
+  "multiarch",
   NULL
 };
 
@@ -2958,6 +2960,12 @@ add_dbus_proxy_args (GPtrArray *argv_array,
 }
 
 #ifdef ENABLE_SECCOMP
+static const uint32_t seccomp_x86_64_extra_arches[] = { SCMP_ARCH_X86, 0, };
+
+#ifdef SCMP_ARCH_AARCH64
+static const uint32_t seccomp_aarch64_extra_arches[] = { SCMP_ARCH_ARM, 0 };
+#endif
+
 static inline void
 cleanup_seccomp (void *p)
 {
@@ -2971,6 +2979,7 @@ static gboolean
 setup_seccomp (GPtrArray  *argv_array,
                GArray     *fd_array,
                const char *arch,
+               gboolean    multiarch,
                gboolean    devel,
                GError    **error)
 {
@@ -3077,16 +3086,27 @@ setup_seccomp (GPtrArray  *argv_array,
   if (arch != NULL)
     {
       uint32_t arch_id = 0;
+      const uint32_t *extra_arches = NULL;
 
       if (strcmp (arch, "i386") == 0)
-        arch_id = SCMP_ARCH_X86;
+        {
+          arch_id = SCMP_ARCH_X86;
+        }
       else if (strcmp (arch, "x86_64") == 0)
-        arch_id = SCMP_ARCH_X86_64;
+        {
+          arch_id = SCMP_ARCH_X86_64;
+          extra_arches = seccomp_x86_64_extra_arches;
+        }
       else if (strcmp (arch, "arm") == 0)
-        arch_id = SCMP_ARCH_ARM;
+        {
+          arch_id = SCMP_ARCH_ARM;
+        }
 #ifdef SCMP_ARCH_AARCH64
       else if (strcmp (arch, "aarch64") == 0)
-        arch_id = SCMP_ARCH_AARCH64;
+        {
+          arch_id = SCMP_ARCH_AARCH64;
+          extra_arches = seccomp_aarch64_extra_arches;
+        }
 #endif
 
       /* We only really need to handle arches on multiarch systems.
@@ -3101,6 +3121,17 @@ setup_seccomp (GPtrArray  *argv_array,
           r = seccomp_arch_add (seccomp, arch_id);
           if (r < 0 && r != -EEXIST)
             return flatpak_fail (error, "Failed to add architecture to seccomp filter");
+
+          if (multiarch && extra_arches != NULL)
+            {
+              unsigned i;
+              for (i = 0; extra_arches[i] != 0; i++)
+                {
+                  r = seccomp_arch_add (seccomp, extra_arches[i]);
+                  if (r < 0 && r != -EEXIST)
+                    return flatpak_fail (error, "Failed to add multiarch architecture to seccomp filter");
+                }
+            }
         }
     }
 
@@ -3323,6 +3354,7 @@ flatpak_run_setup_base_argv (GPtrArray      *argv_array,
   if (!setup_seccomp (argv_array,
                       fd_array,
                       arch,
+                      (flags & FLATPAK_RUN_FLAG_MULTIARCH) != 0,
                       (flags & FLATPAK_RUN_FLAG_DEVEL) != 0,
                       error))
     return FALSE;
@@ -3485,6 +3517,9 @@ flatpak_run_app (const char     *app_ref,
 
   if (app_context->features & FLATPAK_CONTEXT_FEATURE_DEVEL)
     flags |= FLATPAK_RUN_FLAG_DEVEL;
+
+  if (app_context->features & FLATPAK_CONTEXT_FEATURE_MULTIARCH)
+    flags |= FLATPAK_RUN_FLAG_MULTIARCH;
 
   if (!flatpak_run_setup_base_argv (argv_array, fd_array, runtime_files, app_id_dir, app_ref_parts[2], flags, error))
     return FALSE;

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -101,6 +101,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_LOG_SESSION_BUS    = (1 << 2),
   FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS     = (1 << 3),
   FLATPAK_RUN_FLAG_NO_SESSION_HELPER  = (1 << 4),
+  FLATPAK_RUN_FLAG_MULTIARCH          = (1 << 5),
 } FlatpakRunFlags;
 
 gboolean flatpak_run_setup_base_argv (GPtrArray      *argv_array,

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -158,8 +158,14 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
+                </para><para>
+                    The <code>multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code>x86_64</code>
+                    architecture, 32-bit <code>x86</code> binaries will be allowed as
+                    well.
                 </para></listitem>
             </varlistentry>
 
@@ -169,7 +175,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -217,7 +217,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -228,7 +228,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This adds a new `multiarch` feature which allows bundling e.g. 32-bit binaries to be run in a x86_64 environment. By default, the seccomp filter is configured to allow only the native architecture. When the `multiarch` feature is enabled, the filter will be configured to allow running binaries of additional architectures supported. For x86_64, this allows x86 32-bit binaries; and for Aarch64, allows 32-bit ARM binaries.

Application bundles can use the feature e.g. in order to ship 32-bit binaries alongside with a mostly-64-bit application. This is particularly interesting when for applications that might launch themselves prebuilt programs for which 64-bit versions do not exist. For example, the Steam application is available as a 64-bit executable, but some of the games available are 32-bit only. A Flatpak bundle for the Steam application with `multiarch` enabled is able launch the 32-bit games — without the feature enabled, the seccomp filter would prevent them from running.

Multiple-architecture support is enabled by adding the `multiarch` value for the `features` key in the metadata file for a Flatpak:

```ini
  [Context]
  features=multiarch;
```

The corresponding `--allow=multiarch` command line option is supported in `flatpak build-finish` as well.

This is a backport of the upstream patch with commit id `6cbf3b6c0109672aee3e4b895bca5819cc521380`.

https://phabricator.endlessm.com/T13618