### PR TITLE
common: Accept empty/no url in modify_remote

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5093,9 +5093,9 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
   else
     url = g_key_file_get_string (config, group, "url", NULL);
 
-  if (url == NULL || *url == 0)
-    return flatpak_fail (error, "No url for remote %s specified",
-                         remote_name);
+  /* No url => disabled */
+  if (url == NULL)
+    url = g_strdup ("");
 
   /* Add it if its not there yet */
   if (!ostree_repo_remote_change (self->repo, NULL,


### PR DESCRIPTION
This means that the remote is there, but disabled.
This is needed for e.g. bundles without origin url, and when bundles
starting using this codepath this regressed like in:
 https://github.com/flatpak/flatpak/issues/314

https://phabricator.endlessm.com/T13625