### PR TITLE
update --appstream: Actually handle remote argument if specified

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -121,7 +121,7 @@ flatpak_builtin_update (int           argc,
     return FALSE;
 
   if (opt_appstream)
-    return update_appstream (dir, argc >= 2 ? argv[2] : NULL, cancellable, error);
+    return update_appstream (dir, argc >= 2 ? argv[1] : NULL, cancellable, error);
 
   prefs = &argv[1];
   n_prefs = argc - 1;


### PR DESCRIPTION
Without this, the ARM image build tries to update the GNOME runtime appstream and fails because it doesn't exist even though the runtimes for ARM do. We actually only want the appstream from the apps repo, though.

https://phabricator.endlessm.com/T14666