### PR TITLE
system-helper: make sure to run with XDG_DATA_DIRS set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,10 @@ endif
 SUBDIRS += po
 
 %.service: %.service.in config.log
-	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" -e "s|\@extraargs\@||" $< > $@
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" \
+		-e "s|\@localstatedir\@|$(localstatedir)|" \
+		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
+		-e "s|\@extraargs\@||" $< > $@
 
 dbus_servicedir = $(DBUS_SERVICE_DIR)
 service_in_files = $(NULL)

--- a/system-helper/flatpak-system-helper.service.in
+++ b/system-helper/flatpak-system-helper.service.in
@@ -3,5 +3,6 @@ Description=flatpak system helper
 
 [Service]
 BusName=org.freedesktop.Flatpak.SystemHelper
+Environment=XDG_DATA_DIRS=@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/
 ExecStart=@libexecdir@/flatpak-system-helper
 Type=dbus


### PR DESCRIPTION
Otherwise we can see in the log that update-mime-database will complain
about it not being set when installing an application using the system
helper.

https://phabricator.endlessm.com/T14796