### PR TITLE
Require appstream-util for flatpak-builder

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -86,6 +86,7 @@ Package: flatpak-builder
 Architecture: linux-any
 Section: devel
 Depends:
+ appstream-util,
  flatpak (= ${binary:Version}),
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
flatpak-builder tries to run appstream-compose from the host when
finishing builds. Add a dependency on appstream-util to supply it.

https://phabricator.endlessm.com/T14935