### PR TITLE
Don't user user namespaces when bubblewrap is setuid

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3856,7 +3856,6 @@ flatpak_run_setup_base_argv (GPtrArray      *argv_array,
 
   add_args (argv_array,
             "--unshare-pid",
-            "--unshare-user-try",
             "--proc", "/proc",
             "--dir", "/tmp",
             "--dir", "/var/tmp",


### PR DESCRIPTION
It turns out that it is impossible for to get ptrace capabilities
for child user namespaces in the current kernel if the user
namespace is created as root, which is what happens when bwrap
is setuid root (see https://github.com/flatpak/flatpak/issues/557
for details).

This is very problematic, as ptrace rights controls access to
/proc/$pid/root which is what we base the detection of peer
app id and rights on for portals.

For now, we disable user namespaces (except for the case of
unprivileged user namespaces, where it is necessary and works).

https://phabricator.endlessm.com/T15430