### PR TITLE
Return right after having executed the UpdateRemote command via the system helper

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7269,19 +7269,18 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
         g_assert (system_helper != NULL);
 
         g_debug ("Calling system helper: UpdateRemote");
-        if (!flatpak_system_helper_call_update_remote_sync (system_helper,
-                                                            remote,
-                                                            title != NULL ? title : "",
-                                                            default_branch ? default_branch : "",
-                                                            installation ? installation : "",
-                                                            cancellable, error))
-
-          return TRUE;
+        return flatpak_system_helper_call_update_remote_sync (system_helper,
+                                                              remote,
+                                                              title != NULL ? title : "",
+                                                              default_branch ? default_branch : "",
+                                                              installation ? installation : "",
+                                                              cancellable, error);
       }
-
-    /* Update the local remote configuration with the updated info. */
-    if (!flatpak_dir_modify_remote (self, remote, config, NULL, cancellable, error))
-      return FALSE;
+    else
+      {
+        /* Update the local remote configuration with the updated info. */
+        return flatpak_dir_modify_remote (self, remote, config, NULL, cancellable, error);
+      }
   }
 
   return TRUE;


### PR DESCRIPTION
There was a bug in this code that was causing trouble because the remove D-Bus
call to update-remote was returning successfully but the code was still running
through flatpak_dir_modify_remote() even in that case, causing the PolKit auth
dialog to show up, as configure-remote requires authentication.

This was hard to reproduce as it would only happen in situations when the remote
contained a value for a supported parameter (either title or default-branch) in
the server's summary file, as it was the case in the Endless Coding image the first
time it booted, because it would try to update the 'eos' repository's title to the
one in the summary file, and that would only happen once.

This patch makes sure that we either use the update-remote method (when using the
system helper) or the configure-remote method (when not using it) to update the
default branch or title, but never both, and also that the right boolean value
is returned in case of error.

https://phabricator.endlessm.com/T15561