### PR TITLE
project: Compile libglnx with -std=c11

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ libglnx_cflags := \
 	$(BASE_CFLAGS) \
 	"-I$(libglnx_srcpath)" \
 	$(HIDDEN_VISIBILITY_CFLAGS) \
+	-std=c11 \
 	$(NULL)
 libglnx_libs := $(BASE_LIBS)
 include libglnx/Makefile-libglnx.am.inc


### PR DESCRIPTION
Since Glnx uses forloop initial declarations, it should
be compiled with at c11 or c99.

https://phabricator.endlessm.com/T17345