### PR TITLE
Revert "Remove cache directory when install runs out of disk"

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2451,7 +2451,6 @@ flatpak_dir_pull (FlatpakDir          *self,
   g_auto(GLnxConsoleRef) console = { 0, };
   g_autoptr(OstreeAsyncProgress) console_progress = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
-  g_autoptr(GError) my_error = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -2525,16 +2524,9 @@ flatpak_dir_pull (FlatpakDir          *self,
                           subdirs_arg ? (const char **)subdirs_arg->pdata : NULL,
                           ref, rev, flatpak_flags, flags,
                           progress,
-                          cancellable, &my_error))
+                          cancellable, error))
     {
-
-      /* Ensure that cache directory gets cleaned on OOD */
-      if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
-        flatpak_rm_rf (ostree_repo_get_path (repo), cancellable, NULL);
-
-      g_propagate_error (error, g_steal_pointer (&my_error));
       g_prefix_error (error, _("While pulling %s from remote %s: "), ref, repository);
-
       goto out;
     }
 
@@ -2662,7 +2654,6 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
   g_autoptr(GVariant) extra_data_sources = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
   gboolean ret = FALSE;
-  g_autoptr(GError) my_error = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -2762,16 +2753,9 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
   if (!repo_pull_one_untrusted (self->repo, remote_name, url,
                                 subdirs_arg ? (const char **)subdirs_arg->pdata : NULL,
                                 ref, checksum, progress,
-                                cancellable, &my_error))
+                                cancellable, error))
     {
-
-      /* Ensure that cache directory gets cleaned on OOD */
-      if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
-        flatpak_rm_rf (ostree_repo_get_path (self->repo), cancellable, NULL);
-
-      g_propagate_error (error, g_steal_pointer (&my_error));
       g_prefix_error (error, _("While pulling %s from remote %s: "), ref, remote_name);
-
       goto out;
     }
 
@@ -4983,7 +4967,6 @@ flatpak_dir_install (FlatpakDir          *self,
       gboolean gpg_verify_summary;
       gboolean gpg_verify;
       gboolean is_oci;
-      g_autoptr(GError) my_error = NULL;
 
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
@@ -5100,16 +5083,8 @@ flatpak_dir_install (FlatpakDir          *self,
                                                    (const char * const *) subpaths,
                                                    installation ? installation : "",
                                                    cancellable,
-                                                   &my_error)) {
-
-        /* Ensure that we clean cache directory on OOD */
-        if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
-          (void) glnx_shutil_rm_rf_at (AT_FDCWD, child_repo_path, NULL, NULL);
-
-        g_propagate_error (error, g_steal_pointer (&my_error));
-
+                                                   error))
         return FALSE;
-      }
 
       if (child_repo_path)
         (void) glnx_shutil_rm_rf_at (AT_FDCWD, child_repo_path, NULL, NULL);


### PR DESCRIPTION
This reverts commit 4e3767fabff9b960c11e0ea201c7351fcfb36bd9. The
initial upstream review feedback on this patch is that it might
accidentally delete your repo sometimes. Doesn't seem wise to
ship the WIP until that's fixed.

https://phabricator.endlessm.com/T15391