### PR TITLE
debian: Enable --enable-p2p configure flag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+flatpak (0.9.7-1endless2) experimental; urgency=medium
+
+  * Enable --enable-p2p configure option
+    - Add new experimental symbols to the symbols file
+    - Uncomment experimental documentation
+
+ -- Philip Withnall <withnall@endlessm.com>  Thu, 13 Jul 2017 12:29:00 +0100
+
 flatpak (0.9.7-1endless1) experimental; urgency=medium
 
   * Resync Debian packaging changes

--- a/debian/libflatpak0.symbols
+++ b/debian/libflatpak0.symbols
@@ -68,6 +68,7 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_ref_format_ref@Base 0.5.2
  flatpak_ref_get_arch@Base 0.5.2
  flatpak_ref_get_branch@Base 0.5.2
+ flatpak_ref_get_collection_id@Base 0.9.7-1endless2
  flatpak_ref_get_commit@Base 0.5.2
  flatpak_ref_get_kind@Base 0.5.2
  flatpak_ref_get_name@Base 0.5.2
@@ -87,6 +88,7 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_remote_get_nodeps@Base 0.6.13
  flatpak_remote_get_noenumerate@Base 0.5.2
  flatpak_remote_get_prio@Base 0.5.2
+ flatpak_remote_get_remote_type@Base 0.9.7-1endless2
  flatpak_remote_get_title@Base 0.5.2
  flatpak_remote_get_type@Base 0.5.2
  flatpak_remote_get_url@Base 0.5.2

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ override_dh_auto_configure:
 		--enable-docbook-docs \
 		--enable-gtk-doc \
 		--enable-installed-tests \
+		--enable-p2p \
 		--libexecdir=/usr/lib/flatpak \
 		--with-priv-mode=none \
 		--with-html-dir=/usr/share/doc/libflatpak-doc \


### PR DESCRIPTION
 * Enable --enable-p2p configure option
   - Add new experimental symbols to the symbols file
   - Uncomment experimental documentation

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T18242

---

Rebase our patchset on the upstream PR for LAN/USB support (https://github.com/flatpak/flatpak/pull/884) and enable the `--enable-p2p` flag. No major changes to the packaging apart from adding a few new symbols and `--enable-p2p`.

I’m not sure what tag this should eventually be pushed with, since it’s not a new upstream version. Possibly `Version_0.9.7+git20170713.1_debian`.

The code side of this is PR #47.