### PR TITLE
common: Don’t commit arbitrary files into the ostree-metadata branch

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3343,8 +3343,9 @@ flatpak_repo_update (OstreeRepo   *repo,
       if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
         goto out;
 
+      /* Set up an empty mtree. */
       mtree = ostree_mutable_tree_new ();
-      if (!ostree_repo_write_dfd_to_mtree (repo, AT_FDCWD, ".", mtree, NULL, NULL, error))
+      if (!flatpak_mtree_create_root (repo, mtree, cancellable, error))
         goto out;
       if (!ostree_repo_write_mtree (repo, mtree, (GFile **) &repo_file, NULL, error))
         goto out;


### PR DESCRIPTION
When building the ostree-metadata branch (which only happens when
configured with --enable-p2p), we are supposed to create empty commits
which contain only metadata. However, the code to do this was wrong, and
was instead pulling in all the files from the current working directory
and committing them.

Fix that code to actually create an empty commit.

This could have been a fairly serious bug were it not for the fact that
nobody’s using this code because it’s all experimental.

Spotted as part of https://github.com/ostreedev/ostree/pull/1158.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

Closes: #1066
Approved by: alexlarsson

---

This isn’t attached to a particular task; just a recent upstream fix which I really think we ought to have.