### PR TITLE
Update to 0.10.1 (Debian)

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,6 +1,5 @@
 /*.debhelper
 /*.substvars
-/flatpak-builder/
 /flatpak-tests/
 /flatpak/
 /gir1.2-flatpak-1.0/

--- a/debian/autogen.sh
+++ b/debian/autogen.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-gtkdocize
+gtkdocize --copy
 autoreconf -fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+flatpak (0.10.1-1endless0) unstable; urgency=medium
+
+  * New upstream release
+    - Adds appstream-glib as a dependency
+    - Drop some upstreamed Endless patches for config file monitoring
+
+ -- Philip Withnall <withnall@endlessm.com>  Thu, 30 Nov 2017 14:45:00 +0000
+
+flatpak (0.10.1-1) unstable; urgency=medium
+
+  * New upstream release
+    - d/copyright: Update
+    - d/control: Add build-dependency on appstream-glib
+  * d/autogen.sh: Run gtkdocize --copy. Plain gtkdocize replaces
+    gtk-doc.make with a symlink, which dh_autoreconf_clean won't remove,
+    breaking the ability to build twice in a row from the same directory.
+    (See #881915)
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 27 Nov 2017 09:21:56 +0000
+
 flatpak (0.10.0-2endless0) unstable; urgency=medium
 
   * Update Debian packaging from Sid

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,25 +1,300 @@
-flatpak (0.9.8-0endless1) experimental; urgency=medium
+flatpak (0.10.0-2endless0) unstable; urgency=medium
+
+  * Update Debian packaging from Sid
+    - This splits flatpak-builder out into a separate package
+    - Change dh_missing --fail-missing to --list-missing until we have
+      debhelper 10.6, as 10.5 does not know about .examples files (which
+      flatpak packaging uses): we should expect only flatpak-bisect to be
+      listed as missing
+  * Rebase existing Endless patches
+
+ -- Philip Withnall <withnall@endlessm.com>  Wed, 22 Nov 2017 18:00:00 +0000
+
+flatpak (0.10.0-2) unstable; urgency=medium
+
+  * Version the dh-exec build-dependency to (>= 0.23~).
+    The version in oldstable doesn't support build profiles. Strictly
+    speaking 0.15 might be enough, but I'm not going to test with anything
+    older than oldstable-backports.
+  * d/tests/gnome-desktop-testing: Clear proxy-related environment
+    variables, as was previously done for ostree. These are set on
+    Ubuntu's infrastructure to allow accessing the Internet (which we
+    don't need), at the cost of breaking access to 127.0.0.1 (which we
+    do need) for anything that doesn't respect $no_proxy (in
+    particular libostree). (Closes: #880043)
+  * d/control: Set Rules-Requires-Root to no
+    - d/control: Build-depend on gobject-introspection 1.54.1-2 for a
+      fixed dh_girepository to make this work (#880095)
+
+ -- Simon McVittie <smcv@debian.org>  Sun, 05 Nov 2017 14:06:00 +0000
+
+flatpak (0.10.0-1) unstable; urgency=medium
+
+  * d/watch: Track stable-branches (x.y.z where y is even), and fix to
+    cope with multi-digit minor versions
+  * New upstream stable release
+    - Update symbols file
+  * Disable gtk-doc if we are not going to build libflatpak-doc,
+    in particular for architecture-specific builds. Note that it remains
+    in Build-Depends (not Build-Depends-Indep) because it is also needed
+    for gtkdocize during dh_autoreconf.
+  * Do not force --disable-silent-rules, debhelper does this now
+  * Install gtk-doc documentation to the standard /usr/share/gtk-doc,
+    with a symbolic link in /usr/share/doc, instead of the other way
+    round. The gtk-doc documentation is functionally significant (it
+    affects cross-reference generation during build of other packages)
+    so according to Policy §12.3 it is not appropriate for
+    /usr/share/doc.
+    - Install dpkg-maintscript-helper fragments for this migration
+  * Disable documentation generation under nodoc DEB_BUILD_OPTIONS
+  * Disable libflatpak-doc under nodoc build profile
+  * Don't run build-time tests if building only Arch: all packages
+
+ -- Simon McVittie <smcv@debian.org>  Thu, 26 Oct 2017 12:35:52 +0100
+
+flatpak (0.9.99-1) unstable; urgency=medium
 
   * New upstream release
-    - Drop all patches as they are now upstream
-    - Bump libostree dependency to 2017.10
+    - Update symbols file for new ABI
+    - Increase libostree dependency to 2017.12
+  * d/tests/gnome-desktop-testing: Treat debci as a test-specific user
+  * Ensure that /sbin/ldconfig is in tests' PATH
+  * Standards-Version: 4.1.1 (no changes required)
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 09 Oct 2017 14:17:06 +0100
+
+flatpak (0.9.98.2-1) unstable; urgency=medium
+
+  * New upstream release
+    - Drop patch, applied upstream
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 27 Sep 2017 11:51:44 +0100
+
+flatpak (0.9.98-1) unstable; urgency=medium
+
+  * New upstream release
+    - Increase libostree dependency to 2017.11
+  * Add a patch to skip build-time tests if a simple bwrap invocation
+    cannot create all the new namespaces that Flatpak would
+    (Closes: #876743)
+
+ -- Simon McVittie <smcv@debian.org>  Tue, 26 Sep 2017 09:30:48 +0100
+
+flatpak (0.9.12-2) unstable; urgency=medium
+
+  * Merge experimental branch to unstable
+    - src:flatpak no longer has a bundled copy of flatpak-builder, which
+      is now produced by the new src:flatpak-builder
+  * Release to unstable
+
+ -- Simon McVittie <smcv@debian.org>  Fri, 22 Sep 2017 19:06:01 +0100
+
+flatpak (0.9.12-1) experimental; urgency=medium
+
+  * New upstream release
+
+ -- Simon McVittie <smcv@debian.org>  Thu, 14 Sep 2017 11:59:58 +0100
+
+flatpak (0.9.12~builder0.9.11-1) unstable; urgency=medium
+
+  * New upstream release
+  * d/watch: Append ~builderFIXME to the output filenames.
+    They will still need renaming manually to insert the right
+    flatpak-builder version before importing.
+  * d/gbp.conf: Make sure we import the builder tarball on this branch
+
+ -- Simon McVittie <smcv@debian.org>  Thu, 14 Sep 2017 12:06:02 +0100
+
+flatpak (0.9.11-1) experimental; urgency=medium
+
+  * New upstream release
+  * Standards-Version: 4.1.0 (no changes required)
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 13 Sep 2017 21:04:20 +0100
+
+flatpak (0.9.11~builder0.9.11-1) unstable; urgency=medium
+
+  * Switch git branch for upstream imports to upstream/with-builder
+  * New upstream releases
+    - Drop patch to flatpak-builder
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 13 Sep 2017 22:02:55 +0100
+
+flatpak (0.9.10-1) experimental; urgency=medium
+
+  * New upstream release, fixing a regression in the D-Bus proxy
+  * d/upstream/signing-key.asc: Remove; upstream no longer signs
+    released tarballs (and hasn't for a while)
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 04 Sep 2017 10:30:31 +0100
+
+flatpak (0.9.10~builder0.9.9-1) unstable; urgency=medium
+
+  * New upstream release
+    - Drop patches, applied upstream
+    - Update symbols file
+  * Temporarily re-bundle flatpak-builder (which was separated out
+    upstream) while waiting for the new flatpak-builder source package
+    to get through the NEW queue
+    - Run most build steps twice
+    - Add a horrible script to PATH to build against the
+      just-built flatpak
+    - Add patch from upstream to fix FTBFS on non-x86 non-ARM
+      architectures
+    - debian/gbp.conf: Don't merge upstream tags while we bundle flatpak
+      and flatpak-builder
+    - d/copyright: Clarify GPL-2+ status of one source file in
+      flatpak-builder, which means the binary is effectively GPL-2+
+
+ -- Simon McVittie <smcv@debian.org>  Tue, 12 Sep 2017 10:05:10 +0100
+
+flatpak (0.9.9-1) experimental; urgency=medium
+
+  * New upstream release, without flatpak-builder included
+    - Drop patches, applied upstream
+    - Drop all flatpak-builder packaging
+    - Update symbols file
+
+ -- Simon McVittie <smcv@debian.org>  Fri, 01 Sep 2017 17:23:35 +0100
+
+flatpak (0.9.8-2) unstable; urgency=medium
+
+  * Switch git branch for unstable
+  * d/upstream/signing-key.asc: Remove; upstream no longer signs
+    released tarballs (and hasn't for a while)
+  * Standards-Version: 4.1.0 (no changes required)
+  * Release to unstable
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 11 Sep 2017 16:12:27 +0100
+
+flatpak (0.9.8-1) experimental; urgency=medium
+
+  * New upstream release
+    - d/control: Bump libostree dependency
+    - Do not enable experimental P2P feature for now, it needs
+      experimental libostree APIs enabled first
+    - Drop patches, applied upstream
+    - Update symbols file
+  * Add patch from upstream to fix a regression that broke --devel
+  * Add patch already merged upstream to improve test diagnostics
+    (see #870312)
+  * Move flatpak-manifest(5) from flatpak to flatpak-builder.
+    Manifest files are not part of core Flatpak, and are only used by
+    flatpak-builder.
+  * Install flatpak-bisect as an example in flatpak, not as a public
+    entry point in flatpak-builder. It will not be in flatpak-builder
+    after the projects are separated upstream, and does not seem
+    important enough to justify a python3 dependency in flatpak or a
+    separate binary package.
+    - Do not use dh-python
+  * Use dh_missing instead of deprecated dh_install --fail-missing
+  * Merge packaging from unstable
+    - d/rules, d/autogen.sh: Run gtkdocize as well as autoreconf
+      (similar to upstream's autogen.sh but much simpler), replacing
+      gtk-doc.make at build time with the one in Debian's gtk-doc-tools
+    - Standards-Version: 4.0.1 (no changes required)
+  * Add patches to improve test coverage by not skipping most tests when
+    running on tmpfs
+
+ -- Simon McVittie <smcv@debian.org>  Thu, 31 Aug 2017 15:26:32 +0100
+
+flatpak (0.8.7-5) unstable; urgency=medium
+
+  * d/p/tests-Isolate-tests-from-real-home-directory-more-thoroug.patch:
+    Mark as upstreamed for 0.9.8, and move to d/p/0.9.8/ directory
+  * d/p/Improve-test-diagnostics.patch: Add patch to improve test
+    diagnostics (see #870312)
+  * Standards-Version: 4.0.1 (no changes required)
+  * d/p/testlibrary-Skip-tests-that-need-extended-attributes-if-n.patch:
+    Add patch to skip tests that need extended attributes if /var/tmp
+    does not support them (Closes: #870312)
+
+ -- Simon McVittie <smcv@debian.org>  Thu, 31 Aug 2017 11:33:05 +0100
+
+flatpak (0.8.7-4) unstable; urgency=medium
+
   * d/rules, d/autogen.sh: Run gtkdocize as well as autoreconf
     (similar to upstream's autogen.sh but much simpler), replacing
     gtk-doc.make at build time with the one in Debian's gtk-doc-tools
-    (from Debian 0.8.7-4 packaging by Simon McVittie)
-  * Enable --enable-p2p configure option
-    - Uncomment experimental documentation
 
- -- Philip Withnall <withnall@endlessm.com>  Wed, 23 Aug 2017 14:05:00 +0100
+ -- Simon McVittie <smcv@debian.org>  Tue, 18 Jul 2017 23:12:52 +0100
 
-flatpak (0.9.7-1endless1) experimental; urgency=medium
+flatpak (0.8.7-3) unstable; urgency=medium
 
-  * Resync Debian packaging changes
-    - Keep dependency on libgpgme11-dev instead of libgpgme-dev, as our gpgme
-      package is not up to date with Debian experimental.
-    - Keep --with-external-install-dir configure flag.
+  * d/patches/: Add patch backported from 0.9.4, and new patch sent
+    upstream to PR #894, to avoid using the real home directory in tests
+  * d/control: Add libglib2.0-doc, libostree-doc to Build-Depends-Indep
+    so that libflatpak-doc can cross-reference those documentation
+    packages
+  * debian/test.sh: Do not ignore build-time tests' exit status
+  * d/rules: Do not run build-time tests with DEB_BUILD_OPTIONS=nocheck
+  * d/control: Do not build-depend on gnome-desktop-testing. It is only
+    used for the installed-tests.
+  * d/control: Annotate test-only build-dependencies with <!nocheck>
+  * Standards-Version: 4.0.0
+    - Use https URL for format of debian/copyright
 
- -- Philip Withnall <withnall@endlessm.com>  Wed, 12 Jul 2017 15:46:00 +0100
+ -- Simon McVittie <smcv@debian.org>  Tue, 04 Jul 2017 11:59:37 +0100
+
+flatpak (0.8.7-2) unstable; urgency=medium
+
+  * Move upstreamed patch to debian/patches/0.9.1/ to make it obvious
+    when it can be dropped
+  * d/p/0.8.8/: add patches backported from upstream 0.9.4, 0.9.6,
+    together with a new patch to the tests, to restore compatibility
+    with libostree 2017.7 (all applied upstream already)
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 28 Jun 2017 11:55:18 +0100
+
+flatpak (0.8.7-1) unstable; urgency=high
+
+  * New upstream stable release
+    - Security: prevent deploying files with inappropriate permissions
+      (world-writable, setuid, etc.) (Closes: #865413)
+    - Security: make ~/.local/share/flatpak private to user to defend
+      against app vendors that might have released files with
+      inappropriate permissions in the past
+    - If an error occurs during pull, do not double-set an error,
+      which is considered to be invalid
+    - Increase some arbitrary timeouts in a test to make it more
+      reliable
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 21 Jun 2017 09:50:09 +0100
+
+flatpak (0.8.6-1) unstable; urgency=medium
+
+  * New upstream release
+    - Fix the return value type for filtered NameHasOwner() D-Bus calls
+      (upstream issue 817)
+    - Security hardening: Only export .desktop files, D-Bus session
+      services and icons, but not other files that an app might try to
+      export
+    - Allow remote repositories to specify a new GPG key (for key rollover)
+      or a new URL (for location migration) in their signed metadata
+    - Let KDE apps bind-mount ~/.config/kdeglobals into the sandbox:
+      + Allow bind-mounting regular files in the XDG cache, config or data
+        directories, not just directories
+      + Allow bind-mounting files in the XDG directories read-only, not
+        just read/write
+    - Close a race condition in app identification by portals
+    - Cope with a non-default WAYLAND_DISPLAY
+    - Cope with /tmp on the host being a symlink
+    - Clear TMPDIR in the sandbox, fixing sandboxed Spotify
+    - Add X-Flatpak=$app_id to exported .desktop files
+      so that the desktop environment can identify what will be launched
+    - Make the host's /etc/hosts and /etc/host.conf available in the sandbox,
+      fixing sandboxed Spotify
+    - Update Hungarian translation
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 05 Jun 2017 21:30:06 +0100
+
+flatpak (0.8.5-2) unstable; urgency=medium
+
+  * flatpak Recommends xdg-desktop-portal-gtk | xdg-desktop-portal-backend,
+    so that sandboxed apps can communicate with the outside world
+    (Closes: #861068)
+
+ -- Simon McVittie <smcv@debian.org>  Mon, 24 Apr 2017 12:59:09 +0100
 
 flatpak (0.9.7-1) experimental; urgency=medium
 
@@ -55,8 +330,12 @@ flatpak (0.9.6-1) experimental; urgency=high
 flatpak (0.9.5-1) experimental; urgency=medium
 
   * New upstream release
+  * d/p/installed-tests-Install-test-keyring2-to-the-right-place.patch:
+    Drop patch, superseded by an equivalent upstream change
+  * d/p/testlibrary-Call-g_assert_no_error-first.patch:
+    Mark as applied upstream
 
- -- Georges Basile Stavracas Neto <georges@endlessm.com>  Mon, 05 Jun 2017 12:26:57 -0300
+ -- Simon McVittie <smcv@debian.org>  Sun, 18 Jun 2017 21:22:01 +0100
 
 flatpak (0.9.4-1) experimental; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  gtk-doc-tools,
  gtk-update-icon-cache <!nocheck>,
  hicolor-icon-theme <!nocheck>,
+ libappstream-glib-dev,
  libarchive-dev (>= 2.8.0),
  libattr1-dev,
  libcap-dev,

--- a/debian/control
+++ b/debian/control
@@ -13,13 +13,11 @@ Build-Depends:
  dbus,
  debhelper (>= 10~),
  desktop-file-utils <!nocheck>,
- dh-exec,
- dh-python,
- docbook-xml,
- docbook-xsl,
+ dh-exec (>= 0.23~),
+ docbook-xml <!nodoc>,
+ docbook-xsl <!nodoc>,
  fuse <!nocheck>,
- git <!nocheck>,
- gobject-introspection,
+ gobject-introspection (>= 1.54.1-2~),
  gtk-doc-tools,
  gtk-update-icon-cache <!nocheck>,
  hicolor-icon-theme <!nocheck>,
@@ -33,7 +31,7 @@ Build-Depends:
  libglib2.0-dev (>= 2.44),
  libgpgme-dev (>= 1.1.8),
  libjson-glib-dev,
- libostree-dev (>= 2017.10),
+ libostree-dev (>= 2017.12),
  libpolkit-gobject-1-dev,
  libseccomp-dev,
  libsoup2.4-dev,
@@ -42,17 +40,17 @@ Build-Depends:
  libxml2-utils,
  ostree <!nocheck>,
  procps,
- python3,
  shared-mime-info <!nocheck>,
- xmlto,
- xsltproc,
+ xmlto <!nodoc>,
+ xsltproc <!nodoc>,
 Build-Depends-Indep:
  libglib2.0-doc,
  libostree-doc,
-Standards-Version: 4.0.0
+Standards-Version: 4.1.1
 Homepage: http://flatpak.org/
 Vcs-Git: https://anonscm.debian.org/git/collab-maint/flatpak.git
 Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/flatpak.git
+Rules-Requires-Root: no
 
 Package: flatpak
 Architecture: linux-any
@@ -90,34 +88,6 @@ Description: Application deployment framework for desktop apps
  launch sandboxed applications, and the portal services needed to provide
  limited access to resources outside the sandbox.
 
-Package: flatpak-builder
-Architecture: linux-any
-Section: devel
-Depends:
- gir1.2-flatpak-1.0,
- flatpak (= ${binary:Version}),
- ostree (>= 2017.10),
- python3-gi,
- ${misc:Depends},
- ${python3:Depends},
- ${shlibs:Depends},
-Recommends:
- binutils,
- elfutils,
- git,
- patch,
- unzip,
-Suggests: bzr
-Description: Flatpak application building helper
- Flatpak installs, manages and runs sandboxed desktop application bundles.
- See the flatpak package for a more comprehensive description.
- .
- flatpak-builder is a tool that makes it easy to build applications and their
- dependencies by automating the configure && make && make install steps.
- .
- This package also contains the flatpak-bisect script, which can be used to
- identify the first commit that had a particular regression.
-
 Package: flatpak-tests
 Architecture: linux-any
 Section: misc
@@ -128,7 +98,7 @@ Depends:
  flatpak (= ${binary:Version}),
  hicolor-icon-theme,
  gtk-update-icon-cache,
- ostree (>= 2017.10),
+ ostree (>= 2017.12),
  shared-mime-info,
  ${misc:Depends},
  ${shlibs:Depends},
@@ -162,7 +132,7 @@ Depends:
  gir1.2-flatpak-1.0 (= ${binary:Version}),
  libflatpak0 (= ${binary:Version}),
  libglib2.0-dev,
- libostree-dev (>= 2017.10),
+ libostree-dev (>= 2017.12),
  libxml2-dev (>= 2.4),
  pkg-config,
  ${misc:Depends},
@@ -174,6 +144,7 @@ Description: Application deployment framework for desktop apps (development)
  for libflatpak0.
 
 Package: libflatpak-doc
+Build-Profiles: <!nodoc>
 Architecture: all
 Section: doc
 Depends:

--- a/debian/copyright
+++ b/debian/copyright
@@ -20,6 +20,7 @@ Copyright:
  © 2016 Mario Blättermann
  © 2017 Daniel Rusek
  © 2017 Roman Kharin
+ © 2017 Patrick Griffis
 License: LGPL-2.1+
 
 Files:

--- a/debian/copyright
+++ b/debian/copyright
@@ -30,12 +30,6 @@ Copyright:
 License: Autoconf-permissive
 
 Files:
- builder/builder-utils.c
-Copyright:
- © 2001-2016 Red Hat, Inc
-License: GPL-2+
-
-Files:
  m4/attributes.m4
 Copyright:
  © 2006-2008 Diego Pettenò
@@ -49,28 +43,6 @@ Copyright:
  © 2015 David King <amigadave@amigadave.com>
  © 2016 Collabora Ltd.
 License: LGPL-2.1+
-
-License: GPL-2+
- This program is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public
- License as published by the Free Software Foundation; either
- version 2 of the License, or (at your option) any later
- version.
- .
- This program is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied
- warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
- PURPOSE.  See the GNU General Public License for more
- details.
- .
- You should have received a copy of the GNU General Public
- License along with this package; if not, write to the Free
- Software Foundation, Inc., 51 Franklin St, Fifth Floor,
- Boston, MA  02110-1301 USA
-Comment:
- On Debian systems, the full text of the GNU General Public
- License version 2 can be found in the file
- '/usr/share/common-licenses/GPL-2'.
 
 License: GPL-2+ with Autoconf exception
  This program is free software; you can redistribute it

--- a/debian/flatpak-builder.install
+++ b/debian/flatpak-builder.install
@@ -1,3 +1,0 @@
-usr/bin/flatpak-bisect
-usr/bin/flatpak-builder
-usr/share/man/man1/flatpak-builder.1

--- a/debian/flatpak.examples
+++ b/debian/flatpak.examples
@@ -1,0 +1,1 @@
+debian/tmp/usr/bin/flatpak-bisect

--- a/debian/flatpak.install
+++ b/debian/flatpak.install
@@ -1,3 +1,5 @@
+#!/usr/bin/dh-exec
+
 debian/org.freedesktop.Flatpak.pkla     var/lib/polkit-1/localauthority/10-vendor.d/
 etc/X11/Xsession.d
 etc/dbus-1/system.d
@@ -16,42 +18,12 @@ usr/lib/systemd/user/xdg-permission-store.service
 usr/share/bash-completion
 usr/share/dbus-1/services
 usr/share/dbus-1/system-services
-usr/share/doc/flatpak/docbook.css
-usr/share/doc/flatpak/flatpak-docs.html
 usr/share/flatpak
 usr/share/gdm/env.d
 usr/share/locale/*/LC_MESSAGES/flatpak.mo
-usr/share/man/man1/flatpak-build-bundle.1
-usr/share/man/man1/flatpak-build-commit-from.1
-usr/share/man/man1/flatpak-build-export.1
-usr/share/man/man1/flatpak-build-finish.1
-usr/share/man/man1/flatpak-build-import-bundle.1
-usr/share/man/man1/flatpak-build-init.1
-usr/share/man/man1/flatpak-build-sign.1
-usr/share/man/man1/flatpak-build-update-repo.1
-usr/share/man/man1/flatpak-build.1
-usr/share/man/man1/flatpak-document-*.1
-usr/share/man/man1/flatpak-enter.1
-usr/share/man/man1/flatpak-info.1
-usr/share/man/man1/flatpak-install.1
-usr/share/man/man1/flatpak-list.1
-usr/share/man/man1/flatpak-make-current.1
-usr/share/man/man1/flatpak-override.1
-usr/share/man/man1/flatpak-remote-add.1
-usr/share/man/man1/flatpak-remote-delete.1
-usr/share/man/man1/flatpak-remote-ls.1
-usr/share/man/man1/flatpak-remote-modify.1
-usr/share/man/man1/flatpak-remotes.1
-usr/share/man/man1/flatpak-repo.1
-usr/share/man/man1/flatpak-run.1
-usr/share/man/man1/flatpak-uninstall.1
-usr/share/man/man1/flatpak-update.1
-usr/share/man/man1/flatpak.1
-usr/share/man/man5/flatpak-flatpakref.5
-usr/share/man/man5/flatpak-flatpakrepo.5
-usr/share/man/man5/flatpak-installation.5
-usr/share/man/man5/flatpak-manifest.5
-usr/share/man/man5/flatpak-metadata.5
-usr/share/man/man5/flatpak-remote.5
 usr/share/polkit-1/actions
 usr/share/polkit-1/rules.d
+<!nodoc> usr/share/man/man1
+<!nodoc> usr/share/man/man5
+<!nodoc> usr/share/doc/flatpak/docbook.css
+<!nodoc> usr/share/doc/flatpak/flatpak-docs.html

--- a/debian/flatpak.postinst
+++ b/debian/flatpak.postinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+if [ "$1" = configure ]; then
+    # Run a do-nothing command (it just lists configured remotes) for
+    # its side-effect of initializing the shared system-wide repository.
+    flatpak remote-list --system >/dev/null || :
+fi
+
+exit 0
+
+# vim:set sw=4 sts=4 et:

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,7 +1,7 @@
 [DEFAULT]
 pristine-tar = True
 compression = xz
-debian-branch = debian/experimental
+debian-branch = debian/master
 upstream-branch = upstream/latest
 patch-numbers = False
 upstream-vcs-tag = %(version)s

--- a/debian/libflatpak-doc.install
+++ b/debian/libflatpak-doc.install
@@ -1,1 +1,1 @@
-usr/share/doc/libflatpak-doc/flatpak
+usr/share/gtk-doc/html/flatpak

--- a/debian/libflatpak-doc.links
+++ b/debian/libflatpak-doc.links
@@ -1,1 +1,1 @@
-usr/share/doc/libflatpak-doc/flatpak usr/share/gtk-doc/html/flatpak
+usr/share/gtk-doc/html/flatpak usr/share/doc/libflatpak-doc/flatpak

--- a/debian/libflatpak-doc.maintscript
+++ b/debian/libflatpak-doc.maintscript
@@ -1,0 +1,2 @@
+symlink_to_dir /usr/share/gtk-doc/html/flatpak /usr/share/doc/libflatpak-doc/flatpak 0.9.99-2~
+dir_to_symlink /usr/share/doc/libflatpak-doc/flatpak /usr/share/gtk-doc/html/flatpak 0.9.99-2~

--- a/debian/libflatpak0.symbols
+++ b/debian/libflatpak0.symbols
@@ -15,11 +15,13 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_get_supported_arches@Base 0.6.6
  flatpak_get_system_installations@Base 0.8.0
  flatpak_install_flags_get_type@Base 0.6.5
+ flatpak_installation_cleanup_local_refs_sync@Base 0.9.99
  flatpak_installation_create_monitor@Base 0.5.2
  flatpak_installation_drop_caches@Base 0.5.2+git20160516
  flatpak_installation_fetch_remote_metadata_sync@Base 0.5.2
  flatpak_installation_fetch_remote_ref_sync@Base 0.5.2
  flatpak_installation_fetch_remote_size_sync@Base 0.5.2
+ flatpak_installation_get_config@Base 0.10.0
  flatpak_installation_get_current_installed_app@Base 0.5.2
  flatpak_installation_get_display_name@Base 0.8.0
  flatpak_installation_get_id@Base 0.8.0
@@ -48,7 +50,10 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_installation_new_system@Base 0.5.2
  flatpak_installation_new_system_with_id@Base 0.8.0
  flatpak_installation_new_user@Base 0.5.2
+ flatpak_installation_prune_local_repo@Base 0.9.99
+ flatpak_installation_remove_local_ref_sync@Base 0.9.99
  flatpak_installation_remove_remote@Base 0.5.2+git20160516
+ flatpak_installation_set_config_sync@Base 0.10.0
  flatpak_installation_uninstall@Base 0.5.2
  flatpak_installation_update@Base 0.5.2
  flatpak_installation_update_appstream_full_sync@Base 0.9.4
@@ -89,6 +94,7 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_remote_get_nodeps@Base 0.6.13
  flatpak_remote_get_noenumerate@Base 0.5.2
  flatpak_remote_get_prio@Base 0.5.2
+ flatpak_remote_get_remote_type@Base 0.9.9
  flatpak_remote_get_title@Base 0.5.2
  flatpak_remote_get_type@Base 0.5.2
  flatpak_remote_get_url@Base 0.5.2

--- a/debian/rules
+++ b/debian/rules
@@ -3,8 +3,12 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+include /usr/share/dpkg/default.mk
+
+binaries := $(shell dh_listpackages)
+
 %:
-	dh $@ --with=gir,python3
+	dh $@ --with=gir
 
 override_dh_autoreconf:
 	dh_autoreconf \
@@ -13,30 +17,48 @@ override_dh_autoreconf:
 		-- \
 		$(NULL)
 
+configure_options =
+
+ifneq ($(filter nodoc,$(DEB_BUILD_OPTIONS)),)
+configure_options += --disable-docbook-docs
+configure_options += --disable-documentation
+else
+configure_options += --enable-docbook-docs
+configure_options += --enable-documentation
+endif
+
+ifneq ($(filter libflatpak-doc,$(binaries)),)
+configure_options += --enable-gtk-doc
+else
+configure_options += --disable-gtk-doc
+endif
+
 override_dh_auto_configure:
 	dh_auto_configure -- \
-		--disable-silent-rules \
-		--enable-docbook-docs \
-		--enable-gtk-doc \
 		--enable-installed-tests \
 		--enable-p2p \
 		--libexecdir=/usr/lib/flatpak \
 		--with-priv-mode=none \
-		--with-html-dir=/usr/share/doc/libflatpak-doc \
 		--with-privileged-group=sudo \
 		--with-system-bubblewrap=bwrap \
 		--with-systemdsystemunitdir=/lib/systemd/system \
 		--with-external-install-dir=/var/endless-extra/flatpak \
-		$(NULL)
+		$(configure_options)
 
 override_dh_install:
 	install -d debian/tmp/etc/X11/Xsession.d
 	install -m644 debian/tmp/etc/profile.d/flatpak.sh \
 		debian/tmp/etc/X11/Xsession.d/20flatpak
 	rm -f debian/tmp/usr/lib/*/*.la
-	dh_install --fail-missing
+	dh_install
 
-override_dh_auto_test:
+override_dh_missing:
+	dh_missing --list-missing
+
+override_dh_auto_test-arch:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	debian/test.sh
 endif
+
+override_dh_auto_test-indep:
+	@:

--- a/debian/test.sh
+++ b/debian/test.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# The tests want /sbin/ldconfig to be in PATH
+export PATH="$PATH:/usr/sbin:/sbin"
+
 e=0
 dh_auto_test || e=$?
 

--- a/debian/tests/builder
+++ b/debian/tests/builder
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-exec 2>&1
-
-exec gnome-desktop-testing-runner Flatpak/test-builder.sh.test

--- a/debian/tests/builder-python
+++ b/debian/tests/builder-python
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-exec 2>&1
-
-exec gnome-desktop-testing-runner Flatpak/test-builder-python.sh.test

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -3,16 +3,6 @@ Depends:
  build-essential,
  libflatpak-dev,
 
-Tests: builder builder-python
-Restrictions: isolation-machine
-Depends:
- flatpak-builder,
- flatpak-tests,
- git,
- gnome-desktop-testing,
- make,
- python,
-
 Tests: gnome-desktop-testing
 Restrictions: isolation-machine
 Depends:

--- a/debian/tests/gnome-desktop-testing
+++ b/debian/tests/gnome-desktop-testing
@@ -3,33 +3,23 @@
 set -e
 exec 2>&1
 
-e=0
+# The tests want /sbin/ldconfig to be in PATH
+export PATH="$PATH:/usr/sbin:/sbin"
+
+# Ubuntu provides internet access via a proxy, but libostree doesn't need
+# that. However, libostree also doesn't support no_proxy, so it will try
+# to use Ubuntu's proxy for localhost, and fail to reach itself.
+unset ftp_proxy
+unset http_proxy
+unset https_proxy
+unset no_proxy
 
 # Don't pollute the home directory unless this looks like a dedicated
 # autopkgtest environment
-if [ "$(id -nu)" = adt ]; then
-	install -d ~/.flatpak-tests/
-fi
+case "$(id -nu)" in
+	(adt|debci)
+		install -d ~/.flatpak-tests/
+		;;
+esac
 
-gnome-desktop-testing-runner -l Flatpak | while read t; do
-	t="${t%% *}"
-
-	case "$t" in
-		(Flatpak/test-builder.sh.test)
-			# has more dependencies
-			continue
-			;;
-		(Flatpak/test-builder-python.sh.test)
-			# has more dependencies
-			continue
-			;;
-	esac
-
-	gnome-desktop-testing-runner "$t" < /dev/null || touch "$ADTTMP"/failed
-done
-
-if [ -e "$ADTTMP"/failed ]; then
-	exit 1
-fi
-
-exit 0
+exec gnome-desktop-testing-runner Flatpak

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://github.com/@PACKAGE@/@PACKAGE@/releases .*/@PACKAGE@-(\d+\.\d\.\S*)@ARCHIVE_EXT@
+https://github.com/@PACKAGE@/@PACKAGE@/releases .*/@PACKAGE@-(\d+\.\d*[02468]\.\S*)@ARCHIVE_EXT@


### PR DESCRIPTION
flatpak (0.10.1-0endless0) unstable; urgency=medium

  * New upstream release
    - Adds appstream-glib as a dependency
    - Drop some upstreamed Endless patches for config file monitoring

 -- Philip Withnall <withnall@endlessm.com>  Fri, 24 Nov 2017 15:10:00 +0000

flatpak (0.10.0-2endless0) unstable; urgency=medium

  * Update Debian packaging from Sid
    - This splits flatpak-builder out into a separate package
    - Change dh_missing --fail-missing to --list-missing until we have
      debhelper 10.6, as 10.5 does not know about .examples files (which
      flatpak packaging uses): we should expect only flatpak-bisect to be
      listed as missing
  * Rebase existing Endless patches

 -- Philip Withnall <withnall@endlessm.com>  Wed, 22 Nov 2017 18:00:00 +0000

https://phabricator.endlessm.com/T20056

---

Code branch: https://github.com/endlessm/flatpak/pull/61