### PR TITLE
New build release 0.10.1-1endless1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+flatpak (0.10.1-1endless1) unstable; urgency=medium
+
+  * Stop listing temporary remotes when using
+    flatpak_installation_list_remotes
+  * Add new flatpak_installation_list_remotes_by_type
+    - Update symbols file
+  * Mention in the docs the use of the URI for listing refs from remotes
+  * Use collection-refs when listing refs
+  * Add the URL to the remote when creating it from ostree
+  * tests:
+    - Cover listing refs from a remote by URL
+    - Cover listing refs with different collection IDs in remotes
+    - Make the app ID in make-test-app.sh a parameter
+
+ -- Joaquim Rocha <jrocha@endlessm.com>  Web, 20 Dec 2017 01:38:52 +0000
+
 flatpak (0.10.1-1endless0) unstable; urgency=medium
 
   * New upstream release

--- a/debian/libflatpak0.symbols
+++ b/debian/libflatpak0.symbols
@@ -44,6 +44,7 @@ libflatpak.so.0 libflatpak0 #MINVER#
  flatpak_installation_list_remote_refs_sync@Base 0.5.2
  flatpak_installation_list_remote_related_refs_sync@Base 0.6.7
  flatpak_installation_list_remotes@Base 0.5.2
+ flatpak_installation_list_remotes_by_type@Base 0.10.1-1endless1
  flatpak_installation_load_app_overrides@Base 0.5.2
  flatpak_installation_modify_remote@Base 0.5.2+git20160516
  flatpak_installation_new_for_path@Base 0.5.2


### PR DESCRIPTION
This release has the needed changes to support listing temporary
remotes, as well as setting the correct URL in the remote.

https://phabricator.endlessm.com/T20078