### PR TITLE
T20861 Potential fix for OstreeAsyncProgress crash

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2120,7 +2120,14 @@ default_progress_changed (OstreeAsyncProgress *progress,
       glnx_console_text (line);
     }
   else
-    ostree_repo_pull_default_console_progress_changed (progress, user_data);
+    {
+      /* We get some extra calls before we've really started due to the initialization of the
+         extra data, so ignore those */
+      if (ostree_async_progress_get_variant (progress, "outstanding-fetches") == NULL)
+        return;
+
+      ostree_repo_pull_default_console_progress_changed (progress, user_data);
+    }
 }
 
 /* Get the configured collection-id for @remote_name, squashing empty strings into

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6573,7 +6573,11 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
         }
 
       /* The download progress goes up to 97% */
-      new_progress = 5 + ((total_transferred / (gdouble) total) * 92);
+      if (total > 0) {
+        new_progress = 5 + ((total_transferred / (gdouble) total) * 92);
+      } else {
+        new_progress = 97;
+      }
 
       /* And the writing of the objects adds 3% to the progress */
       new_progress += get_write_progress (outstanding_writes);


### PR DESCRIPTION
Here’s a potential fix for the crash in https://phabricator.endlessm.com/T20861. I haven’t tested it other than with compilation, since I’m not sure of the reproduction conditions.

The main fix is the second patch, which I’ve submitted upstream as https://github.com/flatpak/flatpak/pull/1361. The first patch (fix division by zero) is unrelated, but looks like a useful one to have.

https://phabricator.endlessm.com/T20861