### PR TITLE
Backport some commits from flatpak 0.11

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -891,7 +891,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
 
   metadata_dict_v = g_variant_ref_sink (g_variant_dict_end (&metadata_dict));
 
-  /* required for the metadata and the AppStream commits */
+  /* The timestamp is used for the commit metadata and AppStream data */
   if (opt_timestamp != NULL)
     {
       if (!g_time_val_from_iso8601 (opt_timestamp, &ts))
@@ -954,7 +954,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
 
   if (opt_update_appstream &&
       !flatpak_repo_generate_appstream (repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir,
-                                        ts.tv_sec, cancellable, error))
+                                        (opt_timestamp != NULL) ? ts.tv_sec : 0, cancellable, error))
     return FALSE;
 
   if (!opt_no_update_summary &&

--- a/app/flatpak-builtins-info-remote.c
+++ b/app/flatpak-builtins-info-remote.c
@@ -106,6 +106,7 @@ flatpak_builtin_info_remote (int argc, char **argv, GCancellable *cancellable, G
   const char *off = "";
   gboolean friendly = TRUE;
   const char *xa_metadata = NULL;
+  const char *collection_id = NULL;
   g_autoptr(GKeyFile) metakey = NULL;
   guint64 installed_size = 0;
   guint64 download_size = 0;
@@ -169,6 +170,10 @@ flatpak_builtin_info_remote (int argc, char **argv, GCancellable *cancellable, G
       if (xa_metadata == NULL)
         return flatpak_fail (error, "Commit has no metadata");
 
+#ifdef FLATPAK_ENABLE_P2P
+      g_variant_lookup (commit_metadata, "ostree.collection-binding", "&s", &collection_id);
+#endif
+
       if (g_variant_lookup (commit_metadata, "xa.installed-size", "t", &installed_size))
         installed_size = GUINT64_FROM_BE (installed_size);
 
@@ -188,6 +193,8 @@ flatpak_builtin_info_remote (int argc, char **argv, GCancellable *cancellable, G
       g_print ("%s%s%s %s\n", on, _("ID:"), off, parts[1]);
       g_print ("%s%s%s %s\n", on, _("Arch:"), off, parts[2]);
       g_print ("%s%s%s %s\n", on, _("Branch:"), off, parts[3]);
+      if (collection_id != NULL)
+        g_print ("%s%s%s %s\n", on, _("Collection ID:"), off, collection_id);
       g_print ("%s%s%s %s\n", on, _("Date:"), off, formatted_timestamp);
       g_print ("%s%s%s %s\n", on, _("Subject:"), off, subject);
       g_print ("%s%s%s %s\n", on, _("Commit:"), off, commit);

--- a/app/flatpak-builtins-info-remote.c
+++ b/app/flatpak-builtins-info-remote.c
@@ -268,7 +268,14 @@ flatpak_builtin_info_remote (int argc, char **argv, GCancellable *cancellable, G
             g_print ("\n");
 
           if (opt_show_metadata)
-            g_print ("%s", xa_metadata);
+            {
+              g_autoptr(GVariant) c_m = NULL;
+              c_m = g_variant_get_child_value (c_v, 0);
+              g_variant_lookup (c_m, "xa.metadata", "&s", &xa_metadata);
+              if (xa_metadata == NULL)
+                return flatpak_fail (error, "Commit %s has no metadata", c);
+              g_print ("%s", xa_metadata);
+            }
 
           g_free (c);
           c = g_steal_pointer (&p);

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -169,12 +169,14 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   if (friendly)
     {
       g_autoptr(GVariant) commit_v = NULL;
+      g_autoptr(GVariant) commit_metadata = NULL;
       guint64 timestamp;
       g_autofree char *formatted_timestamp = NULL;
       const gchar *subject = NULL;
       const gchar *body = NULL;
       g_autofree char *parent = NULL;
       const char *latest;
+      const char *collection_id = NULL;
 
       latest = flatpak_dir_read_latest (dir, origin, ref, NULL, NULL, NULL);
       if (latest == NULL)
@@ -187,6 +189,12 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
           parent = ostree_commit_get_parent (commit_v);
           timestamp = ostree_commit_get_timestamp (commit_v);
           formatted_timestamp = format_timestamp (timestamp);
+
+          commit_metadata = g_variant_get_child_value (commit_v, 0);
+
+#ifdef FLATPAK_ENABLE_P2P
+          g_variant_lookup (commit_metadata, "ostree.collection-binding", "&s", &collection_id);
+#endif
         }
 
       g_print ("%s%s%s %s\n", on, _("Ref:"), off, ref);
@@ -194,6 +202,8 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       g_print ("%s%s%s %s\n", on, _("Arch:"), off, parts[2]);
       g_print ("%s%s%s %s\n", on, _("Branch:"), off, parts[3]);
       g_print ("%s%s%s %s\n", on, _("Origin:"), off, origin ? origin : "-");
+      if (collection_id)
+        g_print ("%s%s%s %s\n", on, _("Collection ID:"), off, collection_id);
       if (formatted_timestamp)
         g_print ("%s%s%s %s\n", on, _("Date:"), off, formatted_timestamp);
       if (subject)

--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -181,6 +181,9 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
               if (deploy_data == NULL)
                 continue;
 
+              if (g_strcmp0 (flatpak_deploy_data_get_origin (deploy_data), remote) != 0)
+                continue;
+
               if (g_strcmp0 (flatpak_deploy_data_get_commit (deploy_data), checksum) == 0)
                 continue;
             }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5174,7 +5174,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autoptr(GFile) tmp_dir_template = NULL;
   g_autoptr(GVariant) commit_data = NULL;
   g_autofree char *tmp_dir_path = NULL;
-  g_autofree char *alt_id = NULL;
+  const char *alt_id = NULL;
   const char *xa_metadata = NULL;
   const char *xa_ref = NULL;
   g_autofree char *checkout_basename = NULL;
@@ -5223,7 +5223,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
     return FALSE;
 
   commit_metadata = g_variant_get_child_value (commit_data, 0);
-  g_variant_lookup (commit_metadata, "xa.alt-id", "s", &alt_id);
+  g_variant_lookup (commit_metadata, "xa.alt-id", "&s", &alt_id);
 
   checkout_basename = flatpak_dir_get_deploy_subdir (self, checksum, subpaths);
 
@@ -5353,7 +5353,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
         }
     }
 
-  g_variant_lookup (commit_metadata, "xa.ref", "s", &xa_ref);
+  g_variant_lookup (commit_metadata, "xa.ref", "&s", &xa_ref);
   if (xa_ref != NULL)
     {
       gboolean gpg_verify_summary;
@@ -5426,11 +5426,11 @@ flatpak_dir_deploy (FlatpakDir          *self,
   /* Check the metadata in the commit to make sure it matches the actual
      deployed metadata, in case we relied on the one in the commit for
      a decision */
-  g_variant_lookup (commit_metadata, "xa.metadata", "s", &xa_metadata);
+  g_variant_lookup (commit_metadata, "xa.metadata", "&s", &xa_metadata);
   if (xa_metadata != NULL)
     {
       g_autoptr(GFile) metadata_file = g_file_resolve_relative_path (checkoutdir, "metadata");
-      char *metadata_contents;
+      g_autofree char *metadata_contents = NULL;
 
       if (!g_file_load_contents (metadata_file, NULL,
                                  &metadata_contents, NULL, NULL, NULL) ||

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1216,7 +1216,7 @@ flatpak_dir_get_unmaintained_extension_dir (FlatpakDir *self,
                                             const char *arch,
                                             const char *branch)
 {
-  const char *unmaintained_ref;
+  g_autofree char *unmaintained_ref = NULL;
 
   unmaintained_ref = g_build_filename ("extension", name, arch, branch, NULL);
   return g_file_resolve_relative_path (self->basedir, unmaintained_ref);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3353,12 +3353,14 @@ repo_pull_one_local_untrusted (FlatpakDir          *self,
   /* The latter flag was introduced in https://github.com/ostreedev/ostree/pull/926 */
   const OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_UNTRUSTED |OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES;
   GVariantBuilder builder;
+  g_auto(GVariantBuilder) refs_builder = FLATPAK_VARIANT_BUILDER_INITIALIZER;
   g_auto(GLnxConsoleRef) console = { 0, };
   g_autoptr(OstreeAsyncProgress) console_progress = NULL;
   gboolean res;
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
   const char *refs[2] = { NULL, NULL };
   const char *commits[2] = { NULL, NULL };
+  g_autofree char *collection_id = NULL;
 
   if (progress == NULL)
     {
@@ -3370,21 +3372,36 @@ repo_pull_one_local_untrusted (FlatpakDir          *self,
         }
     }
 
-  refs[0] = ref;
-  commits[0] = checksum;
+  if (!repo_get_remote_collection_id (repo, remote_name, &collection_id, error))
+    return FALSE;
+
+  if (collection_id != NULL)
+    {
+      g_variant_builder_init (&refs_builder, G_VARIANT_TYPE ("a(sss)"));
+      g_variant_builder_add (&refs_builder, "(sss)", collection_id, ref, checksum);
+
+      g_variant_builder_add (&builder, "{s@v}", "collection-refs",
+                             g_variant_new_variant (g_variant_builder_end (&refs_builder)));
+    }
+  else
+    {
+      refs[0] = ref;
+      commits[0] = checksum;
+
+      g_variant_builder_add (&builder, "{s@v}", "refs",
+                             g_variant_new_variant (g_variant_new_strv ((const char * const *) refs, -1)));
+      g_variant_builder_add (&builder, "{s@v}", "override-commit-ids",
+                             g_variant_new_variant (g_variant_new_strv ((const char * const *) commits, -1)));
+    }
 
   g_variant_builder_add (&builder, "{s@v}", "flags",
                          g_variant_new_variant (g_variant_new_int32 (flags)));
-  g_variant_builder_add (&builder, "{s@v}", "refs",
-                         g_variant_new_variant (g_variant_new_strv ((const char * const *) refs, -1)));
-  g_variant_builder_add (&builder, "{s@v}", "override-commit-ids",
-                         g_variant_new_variant (g_variant_new_strv ((const char * const *) commits, -1)));
   g_variant_builder_add (&builder, "{s@v}", "override-remote-name",
                          g_variant_new_variant (g_variant_new_string (remote_name)));
   g_variant_builder_add (&builder, "{s@v}", "gpg-verify",
                          g_variant_new_variant (g_variant_new_boolean (TRUE)));
   g_variant_builder_add (&builder, "{s@v}", "gpg-verify-summary",
-                         g_variant_new_variant (g_variant_new_boolean (TRUE)));
+                         g_variant_new_variant (g_variant_new_boolean (collection_id == NULL)));
   g_variant_builder_add (&builder, "{s@v}", "inherit-transaction",
                          g_variant_new_variant (g_variant_new_boolean (TRUE)));
   g_variant_builder_add (&builder, "{s@v}", "update-frequency",

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7925,9 +7925,11 @@ char *
 flatpak_dir_get_remote_collection_id (FlatpakDir *self,
                                       const char *remote_name)
 {
-  char *collection_id = NULL;
+  g_autofree char *collection_id = NULL;
+
   repo_get_remote_collection_id (self->repo, remote_name, &collection_id, NULL);
-  return collection_id;
+
+  return g_steal_pointer (&collection_id);
 }
 
 /* FIXME: For command line completion support for collection–refs over P2P,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2711,7 +2711,10 @@ flatpak_dir_lookup_ref_from_summary (FlatpakDir          *self,
 
   if (!flatpak_summary_lookup_ref (summary, collection_id, ref, &latest_rev, out_variant))
     {
-      flatpak_fail (error, "No such ref '%s' in remote %s", ref, remote);
+      if (collection_id != NULL)
+        flatpak_fail (error, "No such ref (%s, %s) in remote %s", collection_id, ref, remote);
+      else
+        flatpak_fail (error, "No such ref '%s' in remote %s", ref, remote);
       return NULL;
     }
 
@@ -9787,7 +9790,12 @@ flatpak_dir_update_remote_configuration_for_repo_metadata (FlatpakDir    *self,
     return FALSE;
 
   if (!flatpak_summary_lookup_ref (summary, collection_id, OSTREE_REPO_METADATA_REF, &latest_rev, NULL))
-    return flatpak_fail (error, "No such ref '%s' in remote %s", OSTREE_REPO_METADATA_REF, remote);
+    {
+      if (collection_id != NULL)
+        return flatpak_fail (error, "No such ref (%s, %s) in remote %s", collection_id, OSTREE_REPO_METADATA_REF, remote);
+      else
+        return flatpak_fail (error, "No such ref '%s' in remote %s", OSTREE_REPO_METADATA_REF, remote);
+    }
 
   if (!ostree_repo_load_commit (self->repo, latest_rev, &commit_v, NULL, error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1991,6 +1991,12 @@ flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
   return g_strcmp0 (new_checksum, old_checksum) != 0;
 }
 
+static gboolean
+repo_get_remote_collection_id (OstreeRepo  *repo,
+                               const char  *remote_name,
+                               char       **collection_id_out,
+                               GError     **error);
+
 gboolean
 flatpak_dir_update_appstream (FlatpakDir          *self,
                               const char          *remote,
@@ -2023,10 +2029,14 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
       gboolean is_oci;
       g_autoptr(GFile) child_repo_file = NULL;
       g_autofree char *child_repo_path = NULL;
+      g_autofree char *collection_id = NULL;
 
       system_helper = flatpak_dir_get_system_helper (self);
 
       g_assert (system_helper != NULL);
+
+      if (!repo_get_remote_collection_id (self->repo, remote, &collection_id, error))
+        return FALSE;
 
       is_oci = flatpak_dir_get_remote_oci (self, remote);
 
@@ -2066,7 +2076,14 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
           if (child_repo == NULL)
             return FALSE;
 
-          if (!flatpak_dir_remote_fetch_summary (self, remote,
+          /* Avoid fetching the system remote summary on P2P code paths. The
+           * flatpak_dir_pull() call below will cause the true remote's summary
+           * to be pulled into the child repo (which might be the one from a
+           * temporary remote rather than the system remote). Ostree does this
+           * because of the MIRROR flag.*/
+          /* FIXME: P2P appstream updates don't work.*/
+          if (collection_id == NULL &&
+              !flatpak_dir_remote_fetch_summary (self, remote,
                                                  &summary_copy, &summary_sig_copy,
                                                  cancellable, error))
             return FALSE;
@@ -2078,19 +2095,22 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
                                  progress, cancellable, error))
             return FALSE;
 
-          summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
-          if (!g_file_replace_contents (summary_file,
-                                        g_bytes_get_data (summary_copy, NULL),
-                                        g_bytes_get_size (summary_copy),
-                                        NULL, FALSE, 0, NULL, cancellable, NULL))
-            return FALSE;
+          if (summary_copy != NULL)
+            {
+              summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
+              if (!g_file_replace_contents (summary_file,
+                                            g_bytes_get_data (summary_copy, NULL),
+                                            g_bytes_get_size (summary_copy),
+                                            NULL, FALSE, 0, NULL, cancellable, NULL))
+                return FALSE;
 
-          summary_sig_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary.sig");
-          if (!g_file_replace_contents (summary_sig_file,
-                                        g_bytes_get_data (summary_sig_copy, NULL),
-                                        g_bytes_get_size (summary_sig_copy),
-                                        NULL, FALSE, 0, NULL, cancellable, NULL))
-            return FALSE;
+              summary_sig_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary.sig");
+              if (!g_file_replace_contents (summary_sig_file,
+                                            g_bytes_get_data (summary_sig_copy, NULL),
+                                            g_bytes_get_size (summary_sig_copy),
+                                            NULL, FALSE, 0, NULL, cancellable, NULL))
+                return FALSE;
+            }
 
           if (!ostree_repo_resolve_rev (child_repo, branch, TRUE, &new_checksum, error))
             return FALSE;
@@ -6007,7 +6027,13 @@ flatpak_dir_install (FlatpakDir          *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
 
-          if (!flatpak_dir_remote_fetch_summary (self, remote_name,
+          /* Avoid fetching the system remote summary on P2P code paths. The
+           * flatpak_dir_pull() call below will cause the true remote's summary
+           * to be pulled into the child repo (which might be the one from a
+           * temporary remote rather than the system remote). Ostree does this
+           * because of the MIRROR flag.*/
+          if (collection_id == NULL &&
+              !flatpak_dir_remote_fetch_summary (self, remote_name,
                                                  &summary_copy, &summary_sig_copy,
                                                  cancellable, error))
             return FALSE;
@@ -6035,12 +6061,15 @@ flatpak_dir_install (FlatpakDir          *self,
             return FALSE;
 #endif  /* FLATPAK_ENABLE_P2P */
 
-          summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
-          if (!g_file_replace_contents (summary_file,
-                                        g_bytes_get_data (summary_copy, NULL),
-                                        g_bytes_get_size (summary_copy),
-                                        NULL, FALSE, 0, NULL, cancellable, NULL))
-            return FALSE;
+          if (summary_copy != NULL)
+            {
+              summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
+              if (!g_file_replace_contents (summary_file,
+                                            g_bytes_get_data (summary_copy, NULL),
+                                            g_bytes_get_size (summary_copy),
+                                            NULL, FALSE, 0, NULL, cancellable, NULL))
+                return FALSE;
+            }
 
           if (collection_id == NULL)
             {
@@ -6633,7 +6662,13 @@ flatpak_dir_update (FlatpakDir          *self,
           if (child_repo == NULL)
             return FALSE;
 
-          if (!flatpak_dir_remote_fetch_summary (self, remote_name,
+          /* Avoid fetching the system remote summary on P2P code paths. The
+           * flatpak_dir_pull() call below will cause the true remote's summary
+           * to be pulled into the child repo (which might be the one from a
+           * temporary remote rather than the system remote). Ostree does this
+           * because of the MIRROR flag.*/
+          if (collection_id == NULL &&
+              !flatpak_dir_remote_fetch_summary (self, remote_name,
                                                  &summary_copy, &summary_sig_copy,
                                                  cancellable, error))
             return FALSE;
@@ -6657,12 +6692,15 @@ flatpak_dir_update (FlatpakDir          *self,
             return FALSE;
 #endif  /* FLATPAK_ENABLE_P2P */
 
-          summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
-          if (!g_file_replace_contents (summary_file,
-                                        g_bytes_get_data (summary_copy, NULL),
-                                        g_bytes_get_size (summary_copy),
-                                        NULL, FALSE, 0, NULL, cancellable, NULL))
-            return FALSE;
+          if (summary_copy != NULL)
+            {
+              summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
+              if (!g_file_replace_contents (summary_file,
+                                            g_bytes_get_data (summary_copy, NULL),
+                                            g_bytes_get_size (summary_copy),
+                                            NULL, FALSE, 0, NULL, cancellable, NULL))
+                return FALSE;
+            }
 
           if (collection_id == NULL)
             {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2898,10 +2898,8 @@ flatpak_dir_lookup_repo_metadata (FlatpakDir    *self,
         return FALSE;
 
       /* Look up the commit containing the latest repository metadata. */
-      latest_rev = flatpak_dir_lookup_ref_from_summary (self, remote_name,
-                                                        OSTREE_REPO_METADATA_REF,
-                                                        NULL, NULL,
-                                                        cancellable, error);
+      latest_rev = flatpak_dir_read_latest (self, remote_name, OSTREE_REPO_METADATA_REF,
+                                            NULL, cancellable, error);
       if (latest_rev == NULL)
         return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6495,6 +6495,9 @@ flatpak_dir_update (FlatpakDir          *self,
       gboolean gpg_verify;
       g_autofree char *collection_id = NULL;
 
+      if (allow_downgrade)
+        return flatpak_fail (error, "Can't update to a specific commit without root permissions");
+
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1951,6 +1951,101 @@ flatpak_dir_deploy_appstream (FlatpakDir          *self,
   return TRUE;
 }
 
+static gboolean
+repo_get_remote_collection_id (OstreeRepo  *repo,
+                               const char  *remote_name,
+                               char       **collection_id_out,
+                               GError     **error);
+
+#ifdef FLATPAK_ENABLE_P2P
+static void
+async_result_cb (GObject      *obj,
+                 GAsyncResult *result,
+                 gpointer      user_data)
+{
+  GAsyncResult **result_out = user_data;
+  *result_out = g_object_ref (result);
+}
+#endif  /* FLATPAK_ENABLE_P2P */
+
+gboolean
+flatpak_dir_find_latest_rev (FlatpakDir               *self,
+                             const char               *remote,
+                             const char               *ref,
+                             char                    **out_rev,
+                             OstreeRepoFinderResult ***out_results,
+                             GCancellable             *cancellable,
+                             GError                  **error)
+{
+  g_autofree char *collection_id = NULL;
+  g_autofree char *latest_rev = NULL;
+
+  g_return_val_if_fail (out_rev != NULL, FALSE);
+
+  if (!repo_get_remote_collection_id (self->repo, remote, &collection_id, error))
+    return FALSE;
+
+  if (collection_id != NULL)
+    {
+#ifdef FLATPAK_ENABLE_P2P
+      /* Find the latest rev from the remote and its available mirrors, including
+       * LAN and USB sources. */
+      g_autoptr(GMainContext) context = NULL;
+      g_autoptr(GAsyncResult) find_result = NULL;
+      g_auto(OstreeRepoFinderResultv) results = NULL;
+      OstreeCollectionRef collection_ref = { collection_id, (char *) ref };
+      OstreeCollectionRef *collection_refs_to_fetch[2] = { &collection_ref, NULL };
+      gsize i;
+
+      context = g_main_context_new ();
+      g_main_context_push_thread_default (context);
+
+      ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
+                                      NULL  /* no options */,
+                                      NULL  /* default finders */,
+                                      NULL  /* no progress reporting */,
+                                      cancellable, async_result_cb, &find_result);
+
+      while (find_result == NULL)
+        g_main_context_iteration (context, TRUE);
+
+      results = ostree_repo_find_remotes_finish (self->repo, find_result, error);
+      if (results == NULL)
+        return FALSE;
+
+      for (i = 0; results[i] != NULL && latest_rev == NULL; i++)
+        latest_rev = g_strdup (g_hash_table_lookup (results[i]->ref_to_checksum, &collection_ref));
+
+      if (latest_rev == NULL)
+        {
+          flatpak_fail (error, "No such ref (%s, %s) in remote %s or elsewhere",
+                        collection_ref.collection_id, collection_ref.ref_name, remote);
+          return FALSE;
+        }
+
+      if (out_results != NULL)
+        *out_results = g_steal_pointer (&results);
+
+      if (out_rev != NULL)
+        *out_rev = g_steal_pointer (&latest_rev);
+
+#else  /* if !FLATPAK_ENABLE_P2P */
+      g_assert_not_reached ();
+#endif  /* !FLATPAK_ENABLE_P2P */
+    }
+  else
+    {
+      latest_rev = flatpak_dir_lookup_ref_from_summary (self, remote, ref, NULL, NULL, NULL, error);
+      if (latest_rev == NULL)
+        return FALSE;
+
+      if (out_rev != NULL)
+        *out_rev = g_steal_pointer (&latest_rev);
+    }
+
+  return TRUE;
+}
+
 gboolean
 flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
                                         const char          *remote,
@@ -1961,6 +2056,7 @@ flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
   g_autoptr(GFile) active_link = NULL;
   g_autofree char *branch = NULL;
   g_autoptr(GFileInfo) file_info = NULL;
+  g_autoptr(GError) local_error = NULL;
 
   if (!flatpak_dir_maybe_ensure_repo (self, NULL, NULL))
     return TRUE;
@@ -1980,8 +2076,13 @@ flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
 
   branch = g_strdup_printf ("appstream/%s", arch);
 
-  new_checksum = flatpak_dir_lookup_ref_from_summary (self, remote, branch,
-                                                      NULL, NULL, NULL, NULL);
+  if (!flatpak_dir_find_latest_rev (self, remote, branch, &new_checksum,
+                                    NULL, NULL, &local_error))
+    {
+      g_printerr (_("Failed to find latest revision for ref %s from remote %s: %s\n"),
+                  branch, remote, local_error->message);
+      new_checksum = NULL;
+    }
   if (new_checksum == NULL)
     {
       g_debug ("No %s branch for remote %s, ignoring", branch, remote);
@@ -1990,12 +2091,6 @@ flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
 
   return g_strcmp0 (new_checksum, old_checksum) != 0;
 }
-
-static gboolean
-repo_get_remote_collection_id (OstreeRepo  *repo,
-                               const char  *remote_name,
-                               char       **collection_id_out,
-                               GError     **error);
 
 gboolean
 flatpak_dir_update_appstream (FlatpakDir          *self,
@@ -2155,17 +2250,6 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
                                        cancellable,
                                        error);
 }
-
-#ifdef FLATPAK_ENABLE_P2P
-static void
-async_result_cb (GObject      *obj,
-                 GAsyncResult *result,
-                 gpointer      user_data)
-{
-  GAsyncResult **result_out = user_data;
-  *result_out = g_object_ref (result);
-}
-#endif  /* FLATPAK_ENABLE_P2P */
 
 static void
 default_progress_changed (OstreeAsyncProgress *progress,
@@ -6406,7 +6490,6 @@ flatpak_dir_check_for_update (FlatpakDir          *self,
   const char *target_rev = NULL;
   const char *installed_commit;
   const char *installed_alt_id;
-  g_autofree char *collection_id = NULL;
 
   deploy_data = flatpak_dir_get_deploy_data (self, ref,
                                              cancellable, NULL);
@@ -6436,9 +6519,6 @@ flatpak_dir_check_for_update (FlatpakDir          *self,
       return NULL;
     }
 
-  if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, error))
-    return NULL;
-
   if (no_pull)
     {
       remote_and_branch = g_strdup_printf ("%s:%s", remote_name, ref);
@@ -6449,55 +6529,11 @@ flatpak_dir_check_for_update (FlatpakDir          *self,
           return NULL; /* No update, because nothing to update to */
         }
     }
-  else if (collection_id != NULL)
-    {
-#ifdef FLATPAK_ENABLE_P2P
-      /* Find the latest rev from the remote and its available mirrors, including
-       * LAN and USB sources. */
-      g_autoptr(GMainContext) context = NULL;
-      g_autoptr(GAsyncResult) find_result = NULL;
-      g_auto(OstreeRepoFinderResultv) results = NULL;
-      OstreeCollectionRef collection_ref = { collection_id, (char *) ref };
-      OstreeCollectionRef *collection_refs_to_fetch[2] = { &collection_ref, NULL };
-      gsize i;
-
-      context = g_main_context_new ();
-      g_main_context_push_thread_default (context);
-
-      ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
-                                      NULL  /* no options */,
-                                      NULL  /* default finders */,
-                                      NULL  /* no progress reporting */,
-                                      cancellable, async_result_cb, &find_result);
-
-      while (find_result == NULL)
-        g_main_context_iteration (context, TRUE);
-
-      results = ostree_repo_find_remotes_finish (self->repo, find_result, error);
-      if (results == NULL)
-        return NULL;
-
-      for (i = 0; results[i] != NULL && latest_rev == NULL; i++)
-        latest_rev = g_strdup (g_hash_table_lookup (results[i]->ref_to_checksum, &collection_ref));
-
-      if (latest_rev == NULL)
-        {
-          flatpak_fail (error, "No such ref (%s, %s) in remote %s or elsewhere",
-                        collection_ref.collection_id, collection_ref.ref_name, remote_name);
-          return NULL;
-        }
-
-      if (out_results != NULL)
-        *out_results = g_steal_pointer (&results);
-#else  /* if !FLATPAK_ENABLE_P2P */
-      g_assert_not_reached ();
-#endif  /* !FLATPAK_ENABLE_P2P */
-    }
   else
     {
-      latest_rev = flatpak_dir_lookup_ref_from_summary (self, remote_name, ref, NULL, NULL, NULL, error);
-      if (latest_rev == NULL)
-        return NULL;
+      if (!flatpak_dir_find_latest_rev (self, remote_name, ref, &latest_rev,
+                                        out_results, cancellable, error))
+        return FALSE;
     }
 
   if (checksum_or_latest != NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -94,6 +94,13 @@ static GVariant *fetch_remote_summary_file (FlatpakDir    *self,
 static GVariant * flatpak_create_deploy_data_from_old (GFile        *deploy_dir,
                                                        GCancellable *cancellable,
                                                        GError      **error);
+static char * flatpak_dir_lookup_ref_from_summary (FlatpakDir          *self,
+                                                   const char          *remote,
+                                                   const          char *ref,
+                                                   GVariant           **out_variant,
+                                                   GVariant           **out_summary,
+                                                   GCancellable        *cancellable,
+                                                   GError             **error);
 
 typedef struct
 {
@@ -1942,6 +1949,46 @@ flatpak_dir_deploy_appstream (FlatpakDir          *self,
     *out_changed = TRUE;
 
   return TRUE;
+}
+
+gboolean
+flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
+                                        const char          *remote,
+                                        const char          *arch)
+{
+  const char *old_checksum = NULL;
+  g_autofree char *new_checksum = NULL;
+  g_autoptr(GFile) active_link = NULL;
+  g_autofree char *branch = NULL;
+  g_autoptr(GFileInfo) file_info = NULL;
+
+  if (!flatpak_dir_maybe_ensure_repo (self, NULL, NULL))
+    return TRUE;
+
+  active_link = flatpak_build_file (flatpak_dir_get_path (self),
+                                     "appstream",
+                                     remote,
+                                     arch,
+                                     "active",
+                                     NULL);
+
+  file_info = g_file_query_info (active_link, OSTREE_GIO_FAST_QUERYINFO,
+                                 G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                 NULL, NULL);
+  if (file_info != NULL)
+    old_checksum =  g_file_info_get_symlink_target (file_info);
+
+  branch = g_strdup_printf ("appstream/%s", arch);
+
+  new_checksum = flatpak_dir_lookup_ref_from_summary (self, remote, branch,
+                                                      NULL, NULL, NULL, NULL);
+  if (new_checksum == NULL)
+    {
+      g_debug ("No %s branch for remote %s, ignoring", branch, remote);
+      return FALSE; /* No appstream branch, don't update, no error */
+    }
+
+  return g_strcmp0 (new_checksum, old_checksum) != 0;
 }
 
 gboolean

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -353,6 +353,9 @@ gboolean    flatpak_dir_deploy_appstream (FlatpakDir          *self,
                                           gboolean            *out_changed,
                                           GCancellable        *cancellable,
                                           GError             **error);
+gboolean    flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
+                                                    const char          *remote,
+                                                    const char          *arch);
 gboolean    flatpak_dir_update_appstream (FlatpakDir          *self,
                                           const char          *remote,
                                           const char          *arch,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -353,6 +353,13 @@ gboolean    flatpak_dir_deploy_appstream (FlatpakDir          *self,
                                           gboolean            *out_changed,
                                           GCancellable        *cancellable,
                                           GError             **error);
+gboolean    flatpak_dir_find_latest_rev (FlatpakDir               *self,
+                                         const char               *remote,
+                                         const char               *ref,
+                                         char                    **out_rev,
+                                         OstreeRepoFinderResult ***out_results,
+                                         GCancellable             *cancellable,
+                                         GError                  **error);
 gboolean    flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
                                                     const char          *remote,
                                                     const char          *arch);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5438,7 +5438,7 @@ flatpak_number_prompt (int min, int max, const char *prompt, ...)
 {
   char buf[512];
   va_list var_args;
-  gchar *s;
+  g_autofree char *s = NULL;
 
   va_start (var_args, prompt);
   s = g_strdup_vprintf (prompt, var_args);


### PR DESCRIPTION
This is a backport of some upstream commits needed for T20759 along with some other harmless changes. The only one that didn't apply cleanly was 0c52d55ea37b1cc0d30455777f6cb2418d2c79f3 and that ended up being a no-op, so this should be a straightforward merge.

https://phabricator.endlessm.com/T20759