### PR TITLE
run: Add option to disallow a11y bus proxying (cherrypick)

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -44,6 +44,7 @@ static gboolean opt_devel;
 static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_log_a11y_bus;
+static gboolean opt_no_a11y_bus;
 static gboolean opt_file_forwarding;
 static char *opt_runtime;
 static char *opt_runtime_version;
@@ -58,6 +59,7 @@ static GOptionEntry options[] = {
   { "log-session-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_session_bus, N_("Log session bus calls"), NULL },
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
   { "log-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_a11y_bus, N_("Log accessibility bus calls"), NULL },
+  { "no-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_no_a11y_bus, N_("Don't proxy accessibility bus calls"), NULL },
   { "file-forwarding", 0, 0, G_OPTION_ARG_NONE, &opt_file_forwarding, N_("Enable file forwarding"), NULL },
   { NULL }
 };
@@ -179,7 +181,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         (opt_log_session_bus ? FLATPAK_RUN_FLAG_LOG_SESSION_BUS : 0) |
                         (opt_log_system_bus ? FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS : 0) |
                         (opt_log_a11y_bus ? FLATPAK_RUN_FLAG_LOG_A11Y_BUS : 0) |
-                        (opt_file_forwarding ? FLATPAK_RUN_FLAG_FILE_FORWARDING : 0),
+                        (opt_file_forwarding ? FLATPAK_RUN_FLAG_FILE_FORWARDING : 0) |
+                        (opt_no_a11y_bus ? FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY : 0),
                         opt_command,
                         &argv[rest_argv_start + 1],
                         rest_argc - 1,


### PR DESCRIPTION
This isn't needed for servers and starting the a11y bus on a
fresh session bus takes upwards of 15 seconds.

Fixes #1471

Closes: #1486
Approved by: alexlarsson

(cherry-pick from upstream, drop on rebase)

https://phabricator.endlessm.com/T21429