### PR TITLE
lib: Properly handle missing Avahi daemon

### DIFF
--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1105,9 +1105,22 @@ list_remotes_for_configured_remote (FlatpakInstallation  *self,
 
   if (types_filter[FLATPAK_REMOTE_TYPE_LAN])
     {
+      g_autoptr(GError) local_error = NULL;
       finder_avahi = OSTREE_REPO_FINDER (ostree_repo_finder_avahi_new (context));
       finders[finder_index++] = finder_avahi;
-      ostree_repo_finder_avahi_start (OSTREE_REPO_FINDER_AVAHI (finder_avahi), NULL);  /* ignore failure */
+
+      /* The Avahi finder may fail to start on, for example, a CI server. */
+      ostree_repo_finder_avahi_start (OSTREE_REPO_FINDER_AVAHI (finder_avahi), &local_error);
+      if (local_error != NULL)
+        {
+          if (finder_index == 1)
+            return TRUE;
+          else
+            {
+              finders[--finder_index] = NULL;
+              g_clear_object (&finder_avahi);
+            }
+        }
     }
 
   ostree_repo_find_remotes_async (flatpak_dir_get_repo (dir),


### PR DESCRIPTION
In list_remotes_for_configured_remote(), we call
ostree_repo_finder_avahi_start() without checking the error status. This
means the OstreeRepoFinderAvahi instance passed to
ostree_repo_find_remotes_async() could be in an error state, which leads
to flatpak getting infinitely stuck waiting for the result of that
operation. So this commit removes the OstreeRepoFinderAvahi instance
from the array if it failed to start, and returns early if only LAN
remotes were requested. This is also consistent with how ostree itself
handles an error starting the Avahi finder instance in case NULL is
passed to ostree_repo_find_remotes_async() instead of a finders array.

This error condition happens on the Endless OBS server because there's
no Avahi daemon in the chroot used to run "make check".