### PR TITLE
Enable P2P by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,8 +263,8 @@ AC_SUBST([SUDO_BIN])
 # included.
 AC_ARG_ENABLE([p2p],
   [AS_HELP_STRING([--enable-p2p],
-                  [Enable unstable peer to peer support [default=no]])],,
-  [enable_p2p=no])
+                  [Enable unstable peer to peer support [default=yes]])],,
+  [enable_p2p=yes])
 AS_IF([test x$enable_p2p = xyes],[
   PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_P2P_REQS])
 


### PR DESCRIPTION
This commits makes `--enable-p2p` default to yes rather than no, so that
the CI uses it when running tests (since we already use it for the
version of flatpak that goes into Endless). This also has the effect of
making it easier for people who build Flatpak to have a version closer
to what goes into the OS.