### PR TITLE
T22077: T22106: Include relevant flatpak changes

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -57,15 +57,59 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
+typedef gboolean (*DirectoryExportFileFilterFunc) (char *path, gpointer user_data);
+
+typedef struct _BuiltinExportedDirectoryInfo {
+  char                          *path;
+  DirectoryExportFileFilterFunc  filter_func;
+  gpointer                       user_data;
+  GDestroyNotify                 user_data_destroy;
+} BuiltinExportedDirectoryInfo;
+
+static BuiltinExportedDirectoryInfo *
+builtin_exported_directory_info_new (const char                    *path,
+                                     DirectoryExportFileFilterFunc  filter_func,
+                                     gpointer                       user_data,
+                                     GDestroyNotify                 user_data_destroy)
+{
+  BuiltinExportedDirectoryInfo *info = g_new0 (BuiltinExportedDirectoryInfo, 1);
+
+  info->path = g_strdup (path);
+  info->filter_func = filter_func;
+  info->user_data = user_data;
+  info->user_data_destroy = user_data_destroy;
+
+  return info;
+}
+
+static BuiltinExportedDirectoryInfo *
+builtin_exported_directory_info_new_simple (const char *path,
+                                            const char *permissible_prefix)
+{
+  return builtin_exported_directory_info_new (path,
+                                              (DirectoryExportFileFilterFunc) flatpak_has_name_prefix,
+                                              g_strdup (permissible_prefix),
+                                              g_free);
+}
+
+static void
+builtin_exported_directory_info_free (BuiltinExportedDirectoryInfo *info)
+{
+  g_clear_pointer (&info->path, g_free);
+
+  if (info->user_data_destroy != NULL)
+    g_clear_pointer (&info->user_data, info->user_data_destroy);
+}
+
 static gboolean
-export_dir (int           source_parent_fd,
-            const char   *source_name,
-            const char   *source_relpath,
-            int           destination_parent_fd,
-            const char   *destination_name,
-            const char   *required_prefix,
-            GCancellable *cancellable,
-            GError      **error)
+export_dir (int                            source_parent_fd,
+            const char                    *source_name,
+            const char                    *source_relpath,
+            int                            destination_parent_fd,
+            const char                    *destination_name,
+            BuiltinExportedDirectoryInfo  *exported_directory_info,
+            GCancellable                  *cancellable,
+            GError                       **error)
 {
   int res;
 
@@ -126,15 +170,15 @@ export_dir (int           source_parent_fd,
           g_autofree gchar *child_relpath = g_build_filename (source_relpath, dent->d_name, NULL);
 
           if (!export_dir (source_iter.fd, dent->d_name, child_relpath, destination_dfd, dent->d_name,
-                           required_prefix, cancellable, error))
+                           exported_directory_info, cancellable, error))
             return FALSE;
         }
       else if (S_ISREG (stbuf.st_mode))
         {
           source_printable = g_build_filename (source_relpath, dent->d_name, NULL);
 
-
-          if (!flatpak_has_name_prefix (dent->d_name, required_prefix))
+          if (!exported_directory_info->filter_func (dent->d_name,
+                                                     exported_directory_info->user_data))
             {
               g_print (_("Not exporting %s, wrong prefix\n"), source_printable);
               continue;
@@ -174,12 +218,12 @@ export_dir (int           source_parent_fd,
 }
 
 static gboolean
-copy_exports (GFile        *source,
-              GFile        *destination,
-              const char   *source_prefix,
-              const char   *required_prefix,
-              GCancellable *cancellable,
-              GError      **error)
+copy_exports (GFile                         *source,
+              GFile                         *destination,
+              const char                    *source_prefix,
+              BuiltinExportedDirectoryInfo  *exported_directory_info,
+              GCancellable                  *cancellable,
+              GError                       **error)
 {
   if (!flatpak_mkdir_p (destination, cancellable, error))
     return FALSE;
@@ -187,28 +231,75 @@ copy_exports (GFile        *source,
   /* The fds are closed by this call */
   if (!export_dir (AT_FDCWD, flatpak_file_get_path_cached (source), source_prefix,
                    AT_FDCWD, flatpak_file_get_path_cached (destination),
-                   required_prefix, cancellable, error))
+                   exported_directory_info, cancellable, error))
     return FALSE;
 
   return TRUE;
 }
 
+static GStrv
+lookup_permitted_dbus_service_file_prefixes (FlatpakContext  *arg_context,
+                                             const char      *app_id)
+{
+  g_auto(GStrv) dbus_own_name_prefixes =
+    flatpak_context_get_session_bus_policy_allowed_own_names (arg_context);
+  g_autoptr(GPtrArray) permitted_prefixes = g_ptr_array_new_with_free_func (g_free);
+  GStrv iter = dbus_own_name_prefixes;
+
+  g_ptr_array_add (permitted_prefixes, g_strdup (app_id));
+
+  for (; *iter != NULL; ++iter)
+    g_ptr_array_add (permitted_prefixes, g_strdup (*iter));
+
+  g_ptr_array_add (permitted_prefixes, NULL);
+  return (GStrv) g_ptr_array_free (g_steal_pointer (&permitted_prefixes), FALSE);
+}
+
 static gboolean
-collect_exports (GFile *base, const char *app_id, GCancellable *cancellable, GError **error)
+collect_exports (GFile          *base,
+                 const char     *app_id,
+                 FlatpakContext *arg_context,
+                 GCancellable   *cancellable,
+                 GError        **error)
 {
   g_autoptr(GFile) files = NULL;
   g_autoptr(GFile) export = NULL;
-  const char *paths[] = {
-    "share/applications",                 /* Copy desktop files */
-    "share/mime/packages",                /* Copy MIME Type files */
-    "share/icons",                        /* Icons */
-    "share/dbus-1/services",              /* D-Bus service files */
-    "share/gnome-shell/search-providers", /* Search providers */
-    "share/eos-shell-content/splash",     /* Endless splash screens */
-    "share/eos-discovery-feed/content-providers", /* Endless DF content providers */
-    NULL,
-  };
+  g_autoptr(GPtrArray) exported_directory_infos =
+    g_ptr_array_new_with_free_func ((GDestroyNotify) builtin_exported_directory_info_free);
+  g_auto(GStrv) permitted_dbus_service_file_prefixes =
+    lookup_permitted_dbus_service_file_prefixes (arg_context, app_id);
   int i;
+
+  /* Copy desktop files */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/applications", app_id));
+
+  /* Copy MIME type files */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/mime/packages", app_id));
+
+  /* Copy icons */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/icons", app_id));
+
+  /* Copy D-Bus service files */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new ("share/dbus-1/services",
+                                                        (DirectoryExportFileFilterFunc) flatpak_name_matches_one_wildcard_prefix,
+                                                        g_steal_pointer (&permitted_dbus_service_file_prefixes),
+                                                        (GDestroyNotify) g_strfreev));
+
+  /* Copy Search Providers */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/gnome-shell/search-providers", app_id));
+
+  /* Copy eos-shell-content/splash */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/eos-shell-content/splash", app_id));
+
+  /* Copy Endless DF content providers */
+  g_ptr_array_add (exported_directory_infos,
+                   builtin_exported_directory_info_new_simple ("share/eos-discovery-feed/content-providers", app_id));
 
   files = g_file_get_child (base, "files");
 
@@ -220,22 +311,29 @@ collect_exports (GFile *base, const char *app_id, GCancellable *cancellable, GEr
   if (opt_no_exports)
     return TRUE;
 
-  for (i = 0; paths[i]; i++)
+  for (i = 0; i < exported_directory_infos->len; i++)
     {
       g_autoptr(GFile) src = NULL;
-      src = g_file_resolve_relative_path (files, paths[i]);
+      BuiltinExportedDirectoryInfo *info = g_ptr_array_index (exported_directory_infos, i);
+      const char * path = info->path;
+      src = g_file_resolve_relative_path (files, path);
       if (g_file_query_exists (src, cancellable))
         {
-          g_debug ("Exporting from %s", paths[i]);
+          g_debug ("Exporting from %s", path);
           g_autoptr(GFile) dest = NULL;
           g_autoptr(GFile) dest_parent = NULL;
-          dest = g_file_resolve_relative_path (export, paths[i]);
+          dest = g_file_resolve_relative_path (export, path);
           dest_parent = g_file_get_parent (dest);
-          g_debug ("Ensuring export/%s parent exists", paths[i]);
+          g_debug ("Ensuring export/%s parent exists", path);
           if (!flatpak_mkdir_p (dest_parent, cancellable, error))
             return FALSE;
-          g_debug ("Copying from files/%s", paths[i]);
-          if (!copy_exports (src, dest, paths[i], app_id, cancellable, error))
+          g_debug ("Copying from files/%s", path);
+          if (!copy_exports (src,
+                             dest,
+                             path,
+                             info,
+                             cancellable,
+                             error))
             return FALSE;
         }
     }
@@ -570,7 +668,7 @@ flatpak_builtin_build_finish (int argc, char **argv, GCancellable *cancellable, 
   if (!is_runtime)
     {
       g_debug ("Collecting exports");
-      if (!collect_exports (base, id, cancellable, error))
+      if (!collect_exports (base, id, arg_context, cancellable, error))
         return FALSE;
     }
 

--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -74,14 +74,20 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
   for (i = 0; src_extensions[i] != NULL; i++)
     {
       const char *requested_extension = src_extensions[i];
+      g_autofree char *requested_extension_name = NULL;
       gboolean found = FALSE;
+
+      /* Remove any '@' from the name */
+      flatpak_parse_extension_with_tag (requested_extension,
+                                        &requested_extension_name,
+                                        NULL);
 
       for (l = extensions; l != NULL; l = l->next)
         {
           FlatpakExtension *ext = l->data;
 
-          if (strcmp (ext->installed_id, requested_extension) == 0 ||
-              strcmp (ext->id, requested_extension) == 0)
+          if (strcmp (ext->installed_id, requested_extension_name) == 0 ||
+              strcmp (ext->id, requested_extension_name) == 0)
             {
               if (!ext->is_unmaintained)
                 {
@@ -128,7 +134,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
       if (!found)
         {
           g_list_free_full (extensions, (GDestroyNotify) flatpak_extension_free);
-          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension);
+          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension_name);
         }
     }
 

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -75,6 +75,80 @@ child_setup (gpointer user_data)
     fcntl (g_array_index (fd_array, int, i), F_SETFD, 0);
 }
 
+static gboolean
+find_matching_extension_group_in_metakey (GKeyFile    *metakey,
+                                          const char  *id,
+                                          const char  *specified_tag,
+                                          char       **out_extension_group,
+                                          GError     **error)
+{
+  g_auto(GStrv) groups = NULL;
+  g_autofree char *extension_prefix = NULL;
+  const char *last_seen_group = NULL;
+  guint n_extension_groups = 0;
+  GStrv iter = NULL;
+
+  g_return_val_if_fail (out_extension_group != NULL, FALSE);
+
+  groups =  g_key_file_get_groups (metakey, NULL);
+  extension_prefix = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION,
+                                  id,
+                                  NULL);
+
+  for (iter = groups; *iter != NULL; ++iter)
+    {
+      const char *group_name = *iter;
+      const char *extension_name = NULL;;
+      g_autofree char *extension_tag = NULL;
+
+      if (!g_str_has_prefix (group_name, extension_prefix))
+        continue;
+
+      ++n_extension_groups;
+      extension_name = group_name + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION);
+
+      flatpak_parse_extension_with_tag (extension_name,
+                                        NULL,
+                                        &extension_tag);
+
+      /* Check 1: Does this extension have the same tag as the
+       * specified tag (including if both are NULL)? If so, use it */
+      if (g_strcmp0 (extension_tag, specified_tag) == 0)
+        {
+          *out_extension_group = g_strdup (group_name);
+          return TRUE;
+        }
+
+      /* Check 2: Keep track of this extension group as the last
+        * seen one. If it was the only one then we can use it. */
+      last_seen_group = group_name;
+    }
+
+    if (n_extension_groups == 1 && last_seen_group != NULL)
+      {
+        *out_extension_group = g_strdup (last_seen_group);
+        return TRUE;
+      }
+    else if (n_extension_groups == 0)
+      {
+        /* Check 2: No extension groups, this is not an error case as
+         * we check the parent later. */
+        *out_extension_group = NULL;
+        return TRUE;
+      }
+
+  g_set_error (error,
+               G_IO_ERROR,
+               G_IO_ERROR_FAILED,
+               "Unable to resolve extension %s to a unique "
+               "extension point in the parent app or runtime. Consider "
+               "using the 'tag' key in ExtensionOf to disambiguate which "
+               "extension point to build against.",
+               id);
+
+  return FALSE;
+}
+
 gboolean
 flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
@@ -94,6 +168,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   g_autofree char *runtime = NULL;
   g_autofree char *runtime_ref = NULL;
   g_autofree char *extensionof_ref = NULL;
+  g_autofree char *extensionof_tag = NULL;
   g_autofree char *extension_point = NULL;
   g_autofree char *extension_tmpfs_point = NULL;
   g_autoptr(GKeyFile) metakey = NULL;
@@ -186,6 +261,9 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
         is_app_extension = TRUE;
     }
 
+  extensionof_tag = g_key_file_get_string (metakey,
+                                           FLATPAK_METADATA_GROUP_EXTENSION_OF,
+                                           FLATPAK_METADATA_KEY_TAG, NULL);
 
   id = g_key_file_get_string (metakey, group, FLATPAK_METADATA_KEY_NAME, error);
   if (id == NULL)
@@ -255,8 +333,23 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
       x_metakey = flatpak_deploy_get_metadata (extensionof_deploy);
 
-      x_group = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION, id, NULL);
-      if (!g_key_file_has_group (x_metakey, x_group))
+      /* Since we have tagged extensions, it is possible that an extension could
+       * be listed more than once in the "parent" flatpak. In that case, we should
+       * try and disambiguate using the following rules:
+       *
+       * 1. Use the 'tag=' key in the ExtensionOfSection and if not found:
+       * 2. Use the only extension point available if there is only one.
+       * 3. If there are no matching groups, return NULL.
+       * 4. In all other cases, error out.
+       */
+      if (!find_matching_extension_group_in_metakey (x_metakey,
+                                                     id,
+                                                     extensionof_tag,
+                                                     &x_group,
+                                                     error))
+        return FALSE;
+
+      if (x_group == NULL)
         {
           /* Failed, look for subdirectories=true parent */
           char *last_dot = strrchr (id, '.');
@@ -264,10 +357,15 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
           if (last_dot != NULL)
             {
               char *parent_id = g_strndup (id, last_dot - id);
-              g_free (x_group);
-              x_group = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION,
-                                     parent_id, NULL);
-              if (g_key_file_get_boolean (x_metakey, x_group,
+              if (!find_matching_extension_group_in_metakey (x_metakey,
+                                                             parent_id,
+                                                             extensionof_tag,
+                                                             &x_group,
+                                                             error))
+                return FALSE;
+
+              if (x_group != NULL &&
+                  g_key_file_get_boolean (x_metakey, x_group,
                                           FLATPAK_METADATA_KEY_SUBDIRECTORIES,
                                           NULL))
                 x_subdir = last_dot + 1;

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -45,6 +45,7 @@ static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_log_a11y_bus;
 static gboolean opt_no_a11y_bus;
+static gboolean opt_no_documents_portal;
 static gboolean opt_file_forwarding;
 static char *opt_runtime;
 static char *opt_runtime_version;
@@ -60,6 +61,7 @@ static GOptionEntry options[] = {
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
   { "log-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_a11y_bus, N_("Log accessibility bus calls"), NULL },
   { "no-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_no_a11y_bus, N_("Don't proxy accessibility bus calls"), NULL },
+  { "no-documents-portal", 0, 0, G_OPTION_ARG_NONE, &opt_no_documents_portal, N_("Don't start portals"), NULL },
   { "file-forwarding", 0, 0, G_OPTION_ARG_NONE, &opt_file_forwarding, N_("Enable file forwarding"), NULL },
   { NULL }
 };
@@ -182,7 +184,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         (opt_log_system_bus ? FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS : 0) |
                         (opt_log_a11y_bus ? FLATPAK_RUN_FLAG_LOG_A11Y_BUS : 0) |
                         (opt_file_forwarding ? FLATPAK_RUN_FLAG_FILE_FORWARDING : 0) |
-                        (opt_no_a11y_bus ? FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY : 0),
+                        (opt_no_a11y_bus ? FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY : 0) |
+                        (opt_no_documents_portal ? FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL : 0),
                         opt_command,
                         &argv[rest_argv_start + 1],
                         rest_argc - 1,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4618,13 +4618,23 @@ export_desktop_file (const char   *app,
 
   for (i = 0; groups[i] != NULL; i++)
     {
+      g_auto(GStrv) flatpak_run_opts = g_key_file_get_string_list (keyfile, groups[i], "X-Flatpak-RunOptions", NULL, NULL);
+      g_autofree char *flatpak_run_args = format_flatpak_run_args_from_run_opts (flatpak_run_opts);
+
+      g_key_file_remove_key (keyfile, groups[i], "X-Flatpak-RunOptions", NULL);
       g_key_file_remove_key (keyfile, groups[i], "TryExec", NULL);
 
       /* Remove this to make sure nothing tries to execute it outside the sandbox*/
       g_key_file_remove_key (keyfile, groups[i], "X-GNOME-Bugzilla-ExtraInfoScript", NULL);
 
       new_exec = g_string_new ("");
-      g_string_append_printf (new_exec, FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s", escaped_branch, escaped_arch);
+      g_string_append_printf (new_exec,
+                              FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s",
+                              escaped_branch,
+                              escaped_arch);
+
+      if (flatpak_run_args != NULL)
+        g_string_append_printf (new_exec, "%s", flatpak_run_args);
 
       old_exec = g_key_file_get_string (keyfile, groups[i], "Exec", NULL);
       if (old_exec && g_shell_parse_argv (old_exec, &old_argc, &old_argv, NULL) && old_argc >= 1)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4693,15 +4693,56 @@ out:
   return ret;
 }
 
+typedef gboolean (*MultiplePrefixesComparisonFunc) (const char         *path,
+                                                    const char * const *prefixes);
+
+static GStrv
+get_permissible_prefixes (FlatpakContext                  *context,
+                          const char                      *source_path,
+                          const char                      *app_id,
+                          MultiplePrefixesComparisonFunc  *out_match_prefixes_func,
+                          GError                         **error)
+{
+  g_autoptr(GPtrArray) prefixes = NULL;
+
+  g_return_val_if_fail (out_match_prefixes_func != NULL, FALSE);
+
+  prefixes = g_ptr_array_new_with_free_func (g_free);
+
+  /* Create a new pointer array with prefixes including the app
+   * ID and in the case of d-bus service files, the allowed own
+   * names. */
+  g_ptr_array_add (prefixes, g_strdup (app_id));
+
+  if (flatpak_has_path_prefix (source_path, "share/dbus-1/services"))
+    {
+      g_auto(GStrv) owned_dbus_names =
+        flatpak_context_get_session_bus_policy_allowed_own_names (context);
+      GStrv iter = owned_dbus_names;
+
+      for (; *iter != NULL; ++iter)
+        g_ptr_array_add (prefixes, g_strdup (*iter));
+
+      *out_match_prefixes_func = flatpak_name_matches_one_wildcard_prefix;
+    }
+
+  g_ptr_array_add (prefixes, NULL);
+
+  *out_match_prefixes_func = flatpak_name_matches_one_prefix;
+  return (GStrv) g_ptr_array_free (g_steal_pointer (&prefixes), FALSE);
+}
+
 static gboolean
-rewrite_export_dir (const char   *app,
-                    const char   *branch,
-                    const char   *arch,
-                    GKeyFile     *metadata,
-                    int           source_parent_fd,
-                    const char   *source_name,
-                    GCancellable *cancellable,
-                    GError      **error)
+rewrite_export_dir (const char     *app,
+                    const char     *branch,
+                    const char     *arch,
+                    GKeyFile       *metadata,
+                    FlatpakContext *context,
+                    int             source_parent_fd,
+                    const char     *source_name,
+                    const char     *source_path,
+                    GCancellable   *cancellable,
+                    GError        **error)
 {
   gboolean ret = FALSE;
 
@@ -4745,16 +4786,27 @@ rewrite_export_dir (const char   *app,
 
       if (S_ISDIR (stbuf.st_mode))
         {
-          if (!rewrite_export_dir (app, branch, arch, metadata,
+          g_autofree char *path = g_build_filename (source_path, dent->d_name, NULL);
+
+          if (!rewrite_export_dir (app, branch, arch, metadata, context,
                                    source_iter.fd, dent->d_name,
-                                   cancellable, error))
+                                   path, cancellable, error))
             goto out;
         }
       else if (S_ISREG (stbuf.st_mode))
         {
+          MultiplePrefixesComparisonFunc match_prefixes_func;
+          g_auto(GStrv) permissible_prefixes = get_permissible_prefixes (context,
+                                                                         source_path,
+                                                                         app,
+                                                                         &match_prefixes_func,
+                                                                         error);
           g_autofree gchar *new_name = NULL;
 
-          if (!flatpak_has_name_prefix (dent->d_name, app))
+          if (permissible_prefixes == NULL)
+            return FALSE;
+
+          if (!match_prefixes_func (dent->d_name, (const char * const *) permissible_prefixes))
             {
               g_warning ("Non-prefixed filename %s in app %s, removing.", dent->d_name, app);
               if (unlinkat (source_iter.fd, dent->d_name, 0) != 0 && errno != ENOENT)
@@ -4829,10 +4881,24 @@ flatpak_rewrite_export_dir (const char   *app,
                             GError      **error)
 {
   gboolean ret = FALSE;
+  g_autoptr(GFile) parent = g_file_get_parent (source);
+  glnx_autofd int parentfd = -1;
+  g_autofree char *name = g_file_get_basename (source);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+
+  if (!flatpak_context_load_metadata (context, metadata, error))
+    return FALSE;
+
+  if (!glnx_opendirat (AT_FDCWD,
+                       flatpak_file_get_path_cached (parent),
+                       TRUE,
+                       &parentfd,
+                       error))
+    return FALSE;
 
   /* The fds are closed by this call */
-  if (!rewrite_export_dir (app, branch, arch, metadata,
-                           AT_FDCWD, flatpak_file_get_path_cached (source),
+  if (!rewrite_export_dir (app, branch, arch, metadata, context,
+                           parentfd, name, name,
                            cancellable, error))
     goto out;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4914,6 +4914,11 @@ flatpak_rewrite_export_dir (const char   *app,
   g_autoptr(GFile) parent = g_file_get_parent (source);
   glnx_autofd int parentfd = -1;
   g_autofree char *name = g_file_get_basename (source);
+
+  /* Start with a source path of "" - we don't care about
+   * the "export" component and we want to start path traversal
+   * relative to it. */
+  const char *source_path = "";
   g_autoptr(FlatpakContext) context = flatpak_context_new ();
 
   if (!flatpak_context_load_metadata (context, metadata, error))
@@ -4928,7 +4933,7 @@ flatpak_rewrite_export_dir (const char   *app,
 
   /* The fds are closed by this call */
   if (!rewrite_export_dir (app, branch, arch, metadata, context,
-                           parentfd, name, name,
+                           parentfd, name, "",
                            cancellable, error))
     goto out;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4539,6 +4539,26 @@ export_mime_file (int           parent_fd,
   return TRUE;
 }
 
+static char *
+format_flatpak_run_args_from_run_opts (GStrv flatpak_run_args)
+{
+  GString *str = g_string_new ("");
+  GStrv iter = flatpak_run_args;
+
+  if (flatpak_run_args == NULL)
+    return NULL;
+
+  for (; *iter != NULL; ++iter)
+    {
+      if (g_strcmp0 (*iter, "no-a11y-bus") == 0)
+        g_string_append_printf (str, " --no-a11y-bus");
+      else if (g_strcmp0 (*iter, "no-documents-portal") == 0)
+        g_string_append_printf (str, " --no-documents-portal");
+    }
+
+  return g_string_free (str, FALSE);
+}
+
 static gboolean
 export_desktop_file (const char   *app,
                      const char   *branch,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10399,11 +10399,12 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
       groups = g_key_file_get_groups (metakey, NULL);
       for (i = 0; groups[i] != NULL; i++)
         {
-          char *extension;
+          char *tagged_extension;
 
           if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
+              *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
+              g_autofree char *extension = NULL;
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
                                                                 FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
@@ -10420,6 +10421,9 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
               const char *branch;
               g_autofree char *extension_ref = NULL;
               g_autofree char *checksum = NULL;
+
+              /* Parse actual extension name */
+              flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
 
               if (version)
                 branch = version;
@@ -10559,11 +10563,12 @@ flatpak_dir_find_local_related (FlatpakDir *self,
       groups = g_key_file_get_groups (metakey, NULL);
       for (i = 0; groups[i] != NULL; i++)
         {
-          char *extension;
+          char *tagged_extension;
 
           if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
+              *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
+              g_autofree char *extension = NULL;
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
                                                                 FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
@@ -10581,6 +10586,9 @@ flatpak_dir_find_local_related (FlatpakDir *self,
               g_autofree char *prefixed_extension_ref = NULL;
               g_autofree char *checksum = NULL;
               g_autofree char *extension_collection_id = NULL;
+
+              /* Parse actual extension name */
+              flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
 
               if (version)
                 branch = version;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -498,6 +498,22 @@ flatpak_context_set_session_bus_policy (FlatpakContext *context,
   g_hash_table_insert (context->session_bus_policy, g_strdup (name), GINT_TO_POINTER (policy));
 }
 
+GStrv
+flatpak_context_get_session_bus_policy_allowed_own_names (FlatpakContext *context)
+{
+  GHashTableIter iter;
+  gpointer key, value;
+  g_autoptr(GPtrArray) names = g_ptr_array_new_with_free_func (g_free);
+
+  g_hash_table_iter_init (&iter, context->session_bus_policy);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    if (GPOINTER_TO_INT (value) == FLATPAK_POLICY_OWN)
+      g_ptr_array_add (names, g_strdup (key));
+
+  g_ptr_array_add (names, NULL);
+  return (GStrv) g_ptr_array_free (g_steal_pointer (&names), FALSE);
+}
+
 void
 flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                        const char     *name,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -5439,7 +5439,8 @@ flatpak_run_app (const char     *app_ref,
                                       runtime_ref, app_context, &app_info_path, error))
     return FALSE;
 
-  add_document_portal_args (bwrap, app_ref_parts[1], &doc_mount_path);
+  if (!(flags & FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL))
+    add_document_portal_args (bwrap, app_ref_parts[1], &doc_mount_path);
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, flags,
                                          app_ref_parts[1], app_context, app_id_dir, &exports, cancellable, error))

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -157,6 +157,7 @@ void           flatpak_context_allow_host_fs (FlatpakContext *context);
 void           flatpak_context_set_session_bus_policy (FlatpakContext *context,
                                                        const char     *name,
                                                        FlatpakPolicy   policy);
+GStrv          flatpak_context_get_session_bus_policy_allowed_own_names (FlatpakContext *context);
 void           flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                                       const char     *name,
                                                       FlatpakPolicy   policy);

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -186,6 +186,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_DIE_WITH_PARENT    = (1 << 11),
   FLATPAK_RUN_FLAG_LOG_A11Y_BUS       = (1 << 12),
   FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY  = (1 << 13),
+  FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL = (1 << 14),
 } FlatpakRunFlags;
 
 typedef struct _FlatpakExports FlatpakExports;

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -94,6 +94,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
 #define FLATPAK_METADATA_KEY_PRIORITY "priority"
 #define FLATPAK_METADATA_KEY_REF "ref"
+#define FLATPAK_METADATA_KEY_TAG "tag"
 
 extern const char *flatpak_context_sockets[];
 extern const char *flatpak_context_devices[];

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -793,6 +793,50 @@ flatpak_has_name_prefix (const char *string,
     !is_valid_name_character (*rest, FALSE);
 }
 
+gboolean
+flatpak_name_matches_one_prefix (const char         *name,
+                                 const char * const *prefixes)
+{
+  const char * const *iter = prefixes;
+
+  for (; *iter != NULL; ++iter)
+    if (flatpak_has_name_prefix (name, *iter))
+      return TRUE;
+
+  return FALSE;
+}
+
+gboolean
+flatpak_name_matches_one_wildcard_prefix (const char         *name,
+                                          const char * const *wildcarded_prefixes)
+{
+  const char * const *iter = wildcarded_prefixes;
+  g_autofree char *name_without_suffix = g_strdup (name);
+
+  char *first_dot = strrchr (name_without_suffix, '.');
+  *first_dot = '\0';
+
+  for (; *iter != NULL; ++iter)
+    {
+      const char *maybe_wildcarded_prefix = *iter;
+
+      if (g_str_has_suffix (maybe_wildcarded_prefix, ".*"))
+        {
+          g_autofree char *truncated_wildcarded_prefix = g_strndup (maybe_wildcarded_prefix,
+                                                                    strlen (maybe_wildcarded_prefix) - 2);
+
+          if (flatpak_has_name_prefix (name_without_suffix, truncated_wildcarded_prefix))
+            return TRUE;
+        }
+      else if (g_strcmp0 (name_without_suffix, maybe_wildcarded_prefix) == 0)
+        {
+          return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
 static gboolean
 is_valid_initial_branch_character (gint c)
 {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4380,6 +4380,31 @@ add_extension (GKeyFile   *metakey,
   return res;
 }
 
+void
+flatpak_parse_extension_with_tag (const char  *extension,
+                                  char       **name,
+                                  char       **tag)
+{
+  const char *tag_chr = strchr (extension, '@');
+
+  if (tag_chr)
+    {
+      if (name != NULL)
+        *name = g_strndup (extension, tag_chr - extension);
+
+      /* Everything after the @ */
+      if (tag != NULL)
+        *tag = g_strdup (tag_chr + 1);
+
+      return;
+    }
+
+  if (name != NULL)
+    *name = g_strdup (extension);
+
+  if (tag != NULL)
+    *tag = NULL;
+}
 
 GList *
 flatpak_list_extensions (GKeyFile   *metakey,
@@ -4409,8 +4434,11 @@ flatpak_list_extensions (GKeyFile   *metakey,
           g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i],
                                                                FLATPAK_METADATA_KEY_VERSIONS,
                                                                NULL, NULL);
+          g_autofree char *name = NULL;
           const char *default_branches[] = { default_branch, NULL};
           const char **branches;
+
+          flatpak_parse_extension_with_tag (extension, &name, NULL);
 
           if (versions)
             branches = (const char **)versions;
@@ -4422,7 +4450,7 @@ flatpak_list_extensions (GKeyFile   *metakey,
             }
 
           for (j = 0; branches[j] != NULL; j++)
-            res = add_extension (metakey, groups[i], extension, arch, branches[j], res);
+            res = add_extension (metakey, groups[i], name, arch, branches[j], res);
         }
     }
 

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -412,6 +412,10 @@ typedef struct
 
 void flatpak_extension_free (FlatpakExtension *extension);
 
+void flatpak_parse_extension_with_tag (const char  *extension,
+                                       char       **name,
+                                       char       **tag);
+
 GList *flatpak_list_extensions (GKeyFile   *metakey,
                                 const char *arch,
                                 const char *branch);

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -145,6 +145,10 @@ gboolean flatpak_summary_lookup_ref (GVariant    *summary,
 
 gboolean flatpak_has_name_prefix (const char *string,
                                   const char *name);
+gboolean flatpak_name_matches_one_prefix (const char         *string,
+                                          const char * const *prefixes);
+gboolean flatpak_name_matches_one_wildcard_prefix (const char         *string,
+                                                   const char * const *maybe_wildcard_prefixes);
 gboolean flatpak_is_valid_name (const char *string,
                                 GError **error);
 gboolean flatpak_is_valid_branch (const char *string,

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -179,6 +179,15 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--extension-tag=EXTENSION_TAG</option></term>
+
+                <listitem><para>
+                    If building an extension, the tag to use when searching for
+                    the mount point of the extension.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--verbose</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -542,7 +542,11 @@
                 inside the sandbox when they are present on the system. Typical uses
                 for extension points include translations for applications, or debuginfo
                 for sdks. The name of the extension point is specified as part of the
-                group heading.
+                group heading. Since 0.11.4, the name may optionally include a tag
+                in the NAME in the name@tag ref syntax if you wish to use different
+                configurations (eg, versions) of the same extension concurrently.
+                The "tag" is effectively ignored, but is necessary in order to allow
+                the same extension name to be specified more than once.
             </para>
             <variablelist>
                 <varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -692,6 +692,13 @@
                         backported to the 0.8.x branch in 0.8.3.
                     </para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>tag</option> (string)</term>
+                    <listitem><para>
+                        The tag name to use when searching for this extension's mount
+                        point in the parent flatpak. Available since 0.11.4.
+                    </para></listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
         <refsect2>


### PR DESCRIPTION
This branch includes the relevant upstream changes required to make EknServicesMultiplexer and the CompanionAppService with --no-documents-portal and --no-a11y-bus work correctly.

Feel free to merge it after endlessm/master has been rebased, or before.

https://phabricator.endlessm.com/T22077
https://phabricator.endlessm.com/T22106