### PR TITLE
lib: Don't try to use a NULL FlatpakRemoteState

### DIFF
--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -350,7 +350,9 @@ flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
   if (metadata)
     metadata_bytes = g_bytes_new (metadata, strlen (metadata));
 
-  sparse = flatpak_remote_state_lookup_sparse_cache (state, full_ref, NULL);
+  if (state)
+    sparse = flatpak_remote_state_lookup_sparse_cache (state, full_ref, NULL);
+
   if (sparse)
     {
       g_variant_lookup (sparse, "eol", "&s", &eol);


### PR DESCRIPTION
In flatpak_remote_ref_new(), the state parameter is optional, so check
if it's NULL before trying to use it in
flatpak_remote_state_lookup_sparse_cache(). This prevents a seg fault
when GNOME Software is installing a .flatpakref file.

Fixes https://github.com/flatpak/flatpak/issues/1632