### PR TITLE
dir: Save error messages from summary/metadata fetches

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -206,7 +206,9 @@ flatpak_remote_state_free (FlatpakRemoteState *remote_state)
   g_free (remote_state->collection_id);
   g_clear_pointer (&remote_state->summary, g_variant_unref);
   g_clear_pointer (&remote_state->summary_sig_bytes, g_bytes_unref);
+  g_clear_error (&remote_state->summary_fetch_error);
   g_clear_pointer (&remote_state->metadata, g_variant_unref);
+  g_clear_error (&remote_state->metadata_fetch_error);
 
   g_free (remote_state);
 }
@@ -216,7 +218,8 @@ flatpak_remote_state_ensure_summary (FlatpakRemoteState *self,
                                      GError            **error)
 {
   if (self->summary == NULL)
-    return flatpak_fail (error, "Unable to load summary from remote %s", self->remote_name);
+    return flatpak_fail (error, "Unable to load summary from remote %s: %s", self->remote_name,
+                         self->summary_fetch_error != NULL ? self->summary_fetch_error->message : "unknown error");
 
   return TRUE;
 }
@@ -226,7 +229,8 @@ flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
                                       GError            **error)
 {
   if (self->metadata == NULL)
-    return flatpak_fail (error, "Unable to load metadata from remote %s", self->remote_name);
+    return flatpak_fail (error, "Unable to load metadata from remote %s: %s", self->remote_name,
+                         self->metadata_fetch_error != NULL ? self->metadata_fetch_error->message : "unknown error");
 
   return TRUE;
 }
@@ -8274,6 +8278,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         {
           if (optional)
             {
+              state->summary_fetch_error = g_steal_pointer (&local_error);
               g_debug ("Failed to download optional summary");
             }
           else
@@ -8303,6 +8308,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
             {
               /* This happens for instance in the case where a p2p remote is invalid (wrong signature)
                  and we should just silently fail to update to it. */
+              state->metadata_fetch_error = g_steal_pointer (&local_error);
               g_debug ("Failed to download optional metadata");
             }
           else

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -92,7 +92,9 @@ typedef struct
   char *collection_id;
   GVariant *summary;
   GBytes *summary_sig_bytes;
+  GError *summary_fetch_error;
   GVariant *metadata;
+  GError *metadata_fetch_error;
 } FlatpakRemoteState;
 
 void flatpak_remote_state_free (FlatpakRemoteState *remote_state);


### PR DESCRIPTION
On some code paths, flatpak_dir_get_remote_state_optional() is used so
summary fetch errors and metadata fetch errors are treated as non-fatal,
and later flatpak_remote_state_ensure_summary() or
flatpak_remote_state_ensure_metadata() is used, which gives a pretty
unhelpful error message. So this commit saves the error from a failed
summary or metadata fetch into the FlatpakRemoteState object and prints
the message when the flatpak_remote_state_ensure_* function is called to
make that error message more specific and useful.

This also means that the "fail with missing gpg key" unit test in
test-repo.sh is working again. It was broken by the last commit ("dir:
make optional summary really optional) which caused the install
operation in that test to fail later than before with a different error
message.