### PR TITLE
lib: Make the summary optional when fetching metadata

### DIFF
--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2043,7 +2043,7 @@ flatpak_installation_fetch_remote_size_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return FALSE;
 
-  state = flatpak_dir_get_remote_state (dir, remote_name, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, cancellable, error);
   if (state == NULL)
     return FALSE;
 
@@ -2084,7 +2084,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_name, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, cancellable, error);
   if (state == NULL)
     return FALSE;
 


### PR DESCRIPTION
Since the remote metadata can come from either the summary file or the
ostree-metadata ref, and the latter is available offline, there's no
reason to require the summary file when fetching metadata. This commit
changes flatpak_installation_fetch_remote_metadata_sync() and
flatpak_installation_fetch_remote_size_sync() to treat summary fetch
errors as non-fatal. Treating them as fatal is currently preventing
GNOME Software from doing LAN app updates.

GNOME Software should ideally be using metadata from the commits
themselves, but that change will have to wait for the fix for
https://github.com/flatpak/flatpak/issues/1592, I think.