### PR TITLE
common: Pop the thread default main context in find_latest_rev()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2369,6 +2369,9 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
         g_main_context_iteration (context, TRUE);
 
       results = ostree_repo_find_remotes_finish (self->repo, find_result, error);
+
+      g_main_context_pop_thread_default (context);
+
       if (results == NULL)
         return FALSE;
 


### PR DESCRIPTION
The pop was missing, meaning that calling flatpak_dir_find_latest_rev()
corrupted the thread default main context stack of the caller.

Signed-off-by: Philip Withnall <withnall@endlessm.com>