### PR TITLE
dir: Never fsync child repos

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6498,6 +6498,10 @@ flatpak_dir_create_system_child_repo (FlatpakDir   *self,
   if (!ostree_repo_open (repo, NULL, error))
     return NULL;
 
+  /* We don't need to sync the child repos, they are never used for stable storage, and we
+     verify + fsync when importing to stable storage */
+  ostree_repo_set_disable_fsync (repo, TRUE);
+
   /* Create a commitpartial in the child repo to ensure we download everything, because
      any commitpartial state in the parent will not be inherited */
   if (optional_commit)


### PR DESCRIPTION
There is no need to force a fsync after pulling into the child repo,
because we will anyway copy/verify it into the system repo. It is
never used for stable storage.

This makes system installation faster.

Closes: #1808
Approved by: alexlarsson

(cherry picked from commit 9901ce875fc88db49ec3f6e72ffa850ab3d22ac9)
Signed-off-by: Robert McQueen <rob@endlessm.com>

https://phabricator.endlessm.com/T23081