### PR TITLE
profile/flatpak.sh.in: add export/bin dirs to PATH

### DIFF
--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -1,7 +1,13 @@
-# @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
+# @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS and PATH
 
 if [ "${XDG_DATA_DIRS#*flatpak}" = "${XDG_DATA_DIRS}" ]; then
     XDG_DATA_DIRS="${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share:@externalinstalldir@/exports/share/:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 fi
 
 export XDG_DATA_DIRS
+
+if [ "${PATH#*flatpak}" = "${PATH}" ]; then
+    PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games}:${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak/exports/bin:@localstatedir@/lib/flatpak/exports/bin:@externalinstalldir@/exports/bin"
+fi
+
+export PATH


### PR DESCRIPTION
Add the com.id.foo wrappers which are created by flatpak in the
export/bin dir to the default PATH.

https://phabricator.endlessm.com/T22334