### PR TITLE
common/dir: Consider co-existence of min-free-space-* options

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2219,12 +2219,12 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
       orig_add_remotes_config_dir = g_key_file_get_value (orig_config, "core", "add-remotes-config-dir", NULL);
 
       if (orig_min_free_space_size == NULL ||
-          orig_min_free_space_percent != NULL ||
           orig_add_remotes_config_dir == NULL)
         new_config = ostree_repo_copy_config (repo);
 
       /* Scrap previously written min-free-space-percent=0 and replace it with min-free-space-size */
-      if (orig_min_free_space_percent != NULL &&
+      if (orig_min_free_space_size == NULL &&
+          orig_min_free_space_percent != NULL &&
           g_ascii_string_to_unsigned (orig_min_free_space_percent, 10,
                                       0, G_MAXUINT64,
                                       &min_free_space_percent_int, &my_error))


### PR DESCRIPTION
Recently, we ported flatpak's logic to disable min-free-space-percent=0
to min-free-space-size but at that stage only one of the config option
was allowed to be mentioned in the config by ostree.

Recent ostree release now support co-existing of both options therefore,
flatpak should consider the co-existence and re-write the config
accordingly. Config is re-written in case of:

1) It has min-free-space-percent=0 only. (That is probably from the
   previous re-writes).
2) If there are no min-free-space-* options.

Other than that, the config remains unchanged and the co-existence
of these options is governed by ostree.

https://phabricator.endlessm.com/T23379