### PR TITLE
RFC: Support migration from old app-ids to new app-id

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -233,6 +233,9 @@ const char *        flatpak_deploy_data_get_alt_id (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_runtime (GVariant *deploy_data);
+const char **       flatpak_deploy_data_get_previous_ids (GVariant *deploy_data,
+                                                          gsize    *length);
+
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
 GVariant *     flatpak_load_deploy_data (GFile        *deploy_dir,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1935,6 +1935,25 @@ flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data)
   return eol;
 }
 
+const char **
+flatpak_deploy_data_get_previous_ids (GVariant *deploy_data, gsize *length)
+{
+  g_autoptr(GVariant) metadata = g_variant_get_child_value (deploy_data, 4);
+  g_autoptr(GVariant) previous_ids_v = NULL;
+  const char **previous_ids = NULL;
+
+  previous_ids_v = g_variant_lookup_value (metadata, "previous-ids", NULL);
+  if (previous_ids_v)
+    previous_ids = g_variant_get_strv (previous_ids_v, length);
+  else
+    {
+      if (length != NULL)
+        *length = 0;
+    }
+
+  return previous_ids;
+}
+
 const char *
 flatpak_deploy_data_get_runtime (GVariant *deploy_data)
 {
@@ -6990,6 +7009,13 @@ flatpak_dir_deploy (FlatpakDir          *self,
   if (application_runtime)
     g_variant_builder_add (&metadata_builder, "{s@v}", "runtime",
                            g_variant_new_variant (g_variant_new_string (application_runtime)));
+  if (old_deploy_data)
+    {
+      g_autofree const char **previous_ids = flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL);
+      if (previous_ids)
+        g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
+                               g_variant_new_variant (g_variant_new_strv ((const char * const *) previous_ids, -1)));
+    }
 
   deploy_data = flatpak_dir_new_deploy_data (origin,
                                              checksum,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2963,7 +2963,45 @@ flatpak_run_app (const char     *app_ref,
 
   if (app_deploy != NULL)
     {
+      g_autofree const char **previous_ids = NULL;
+      gsize len = 0;
+
       app_files = flatpak_deploy_get_files (app_deploy);
+
+      g_autoptr (GFile) current_data_dir = flatpak_get_data_dir (app_ref_parts[1]);
+      previous_ids = flatpak_deploy_data_get_previous_ids (app_deploy_data, &len);
+      while (len > 0)
+        {
+          g_autoptr (GFile) previous_data_dir = NULL;
+          g_autoptr (GError) local_error = NULL;
+          g_autofree char *previous_data_path = NULL;
+          g_autofree char *current_data_path = NULL;
+
+          if (g_file_query_exists (current_data_dir, cancellable))
+            break;
+
+          previous_data_dir = flatpak_get_data_dir (previous_ids[--len]);
+          if (!g_file_query_exists (previous_data_dir, cancellable))
+            continue;
+
+          if (!flatpak_file_rename (previous_data_dir,
+                                    current_data_dir,
+                                    cancellable, &local_error))
+             {
+               g_propagate_error (error, g_steal_pointer (&local_error));
+               return FALSE;
+             }
+
+           current_data_path = g_file_get_path (current_data_dir);
+           previous_data_path = g_file_get_path (previous_data_dir);
+           if (symlink (current_data_path, previous_data_path) == 0)
+             break;
+           else
+             {
+               glnx_set_error_from_errno (error);
+               return FALSE;
+             }
+        }
 
       real_app_id_dir = flatpak_ensure_data_dir (app_ref_parts[1], cancellable, error);
       if (real_app_id_dir == NULL)


### PR DESCRIPTION
flatpak run checks if there is any previous-ids for the app and
sees if there is a corresponding app-dir in ~/.var/app/ .
If so, it renames that app-dir to the new app-id and provides
a symlink from old app-id dir to new app-id dir. The symlink is
needed because even though the XDG_DATA_DIR and other environment
variables are set to the new ID by flatpak run, the app itself
could've stored (eg in GSettings, or other files) paths which
contained the old ID.

https://phabricator.endlessm.com/T23532