### PR TITLE
common/installation: Search dynamic remotes for appstream2 also

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1115,8 +1115,10 @@ list_remotes_for_configured_remote (FlatpakInstallation *self,
 {
   g_autofree gchar *collection_id = NULL;
   OstreeCollectionRef ref;
-  const OstreeCollectionRef *refs[2] = { NULL, };
+  OstreeCollectionRef ref2;
+  const OstreeCollectionRef *refs[3] = { NULL, };
   g_autofree gchar *appstream_ref = NULL;
+  g_autofree gchar *appstream2_ref = NULL;
 
   g_auto(OstreeRepoFinderResultv) results = NULL;
   g_autoptr(GAsyncResult) result = NULL;
@@ -1144,6 +1146,10 @@ list_remotes_for_configured_remote (FlatpakInstallation *self,
   ref.collection_id = collection_id;
   ref.ref_name = appstream_ref;
   refs[0] = &ref;
+  appstream2_ref = g_strdup_printf ("appstream2/%s", flatpak_get_arch ());
+  ref2.collection_id = collection_id;
+  ref2.ref_name = appstream2_ref;
+  refs[1] = &ref2;
 
   if (types_filter[FLATPAK_REMOTE_TYPE_USB])
     {


### PR DESCRIPTION
Flatpak has API called flatpak_installation_list_remotes_by_type() which
can list dynamic (LAN/USB) remotes that mirror configured remotes in an
installation. It does this by searching them for the appstream/<arch>
ref, such as appstream/x86_64. But Flatpak now supports
appstream2/<arch> as a way to provide the appstream data as uncompressed
XML, and it's possible that a USB created with `flatpak create-usb` (or
a LAN peer) only has the appstream2 ref available for a certain
collection ID. So this commit changes
list_remotes_for_configured_remote() so that it looks for both
appstream/<arch> and appstream2/<arch>, which makes
flatpak_installation_list_remotes_by_type() robust to that scenario.