### PR TITLE
system-helper: set IO class to idle

### DIFF
--- a/system-helper/flatpak-system-helper.service.in
+++ b/system-helper/flatpak-system-helper.service.in
@@ -6,3 +6,4 @@ BusName=org.freedesktop.Flatpak.SystemHelper
 Environment=XDG_DATA_DIRS=@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/
 ExecStart=@libexecdir@/flatpak-system-helper
 Type=dbus
+IOSchedulingClass=idle


### PR DESCRIPTION
Our benchmarks show this significantly reduces the interactivity impact of
ongoing Flatpak operations while the user is continuing other tasks on the
system. The effect is very pronounced with the default CFQ scheduler, and in
combination with BFQ, using the idle class improves the worst case to nearly
the same as an unloaded system.

https://phabricator.endlessm.com/T22479