### PR TITLE
dir: Support an eos.collection-id metadata key

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11498,6 +11498,7 @@ flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *self,
     "xa.gpg-keys",
     "xa.redirect-url",
     "xa.collection-id",
+    "eos.collection-id", /* Endless specific and temporary */
     NULL
   };
 
@@ -11540,7 +11541,7 @@ flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *self,
                     {
                       if (strcmp (key, "xa.redirect-url") == 0)
                         g_ptr_array_add (updated_params, g_strdup ("url"));
-                      else if (strcmp (key, "xa.collection-id") == 0)
+                      else if (strcmp (key, "xa.collection-id") == 0 || strcmp (key, "eos.collection-id") == 0)
                         g_ptr_array_add (updated_params, g_strdup ("collection-id"));
                       else
                         g_ptr_array_add (updated_params, g_strdup (key));


### PR DESCRIPTION
Currently flatpak looks for the key "xa.collection-id" in a remote's
metadata to decide whether to update its config with a collection ID.
This commit implements an Endless specific version of it,
eos.collection-id. The purpose of this is so that we can enable a
collection ID on the flathub remote for Endless users without enabling
it for all Flathub users, which is considered risky at the moment.
The Endless versions of flatpak and ostree have patches for various
bugs which other distributions don't have yet.

Eventually once Flathub deploys a collection ID for all users, this
patch should be dropped.

For more discussion see https://phabricator.endlessm.com/T19363#627411

https://phabricator.endlessm.com/T23414