### PR TITLE
Add previous-ids to exported .desktop files

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5709,16 +5709,17 @@ format_flatpak_run_args_from_run_opts (GStrv flatpak_run_args)
 }
 
 static gboolean
-export_desktop_file (const char   *app,
-                     const char   *branch,
-                     const char   *arch,
-                     GKeyFile     *metadata,
-                     int           parent_fd,
-                     const char   *name,
-                     struct stat  *stat_buf,
-                     char        **target,
-                     GCancellable *cancellable,
-                     GError      **error)
+export_desktop_file (const char         *app,
+                     const char         *branch,
+                     const char         *arch,
+                     GKeyFile           *metadata,
+                     const char * const *previous_ids,
+                     int                 parent_fd,
+                     const char         *name,
+                     struct stat        *stat_buf,
+                     char              **target,
+                     GCancellable       *cancellable,
+                     GError            **error)
 {
   gboolean ret = FALSE;
   glnx_autofd int desktop_fd = -1;
@@ -5782,6 +5783,68 @@ export_desktop_file (const char   *app,
 
       /* Add a marker so consumers can easily find out that this launches a sandbox */
       g_key_file_set_string (keyfile, G_KEY_FILE_DESKTOP_GROUP, "X-Flatpak", app);
+
+      /* If the app has been renamed, add its old .desktop filename to
+       * X-Flatpak-RenamedFrom in the new .desktop file, taking care not to
+       * introduce duplicates.
+       */
+      if (previous_ids != NULL)
+        {
+          const char *X_FLATPAK_RENAMED_FROM = "X-Flatpak-RenamedFrom";
+          g_auto(GStrv) renamed_from = g_key_file_get_string_list (keyfile,
+                                                                   G_KEY_FILE_DESKTOP_GROUP,
+                                                                   X_FLATPAK_RENAMED_FROM,
+                                                                   NULL, NULL);
+          g_autoptr(GPtrArray) merged = g_ptr_array_new_with_free_func (g_free);
+          g_autoptr(GHashTable) seen = g_hash_table_new (g_str_hash, g_str_equal);
+          const char *new_suffix;
+          gsize i;
+
+
+          for (i = 0; renamed_from != NULL && renamed_from[i] != NULL; i++)
+            {
+              if (!g_hash_table_contains (seen, renamed_from[i]))
+                {
+                  gchar *copy = g_strdup (renamed_from[i]);
+                  g_hash_table_insert (seen, copy, copy);
+                  g_ptr_array_add (merged, g_steal_pointer (&copy));
+                }
+            }
+
+          /* If an app was renamed from com.example.Foo to net.example.Bar, and
+           * the new version exports net.example.Bar-suffix.desktop, we assume the
+           * old version exported com.example.Foo-suffix.desktop.
+           *
+           * This assertion is true because
+           * flatpak_name_matches_one_wildcard_prefix() is called on all
+           * exported files before we get here.
+           */
+          g_assert (g_str_has_prefix (name, app));
+          /* ".desktop" for the "main" desktop file; something like
+           * "-suffix.desktop" for extra ones.
+           */
+          new_suffix = name + strlen (app);
+
+          for (i = 0; previous_ids[i] != NULL; i++)
+            {
+              g_autofree gchar *previous_desktop = g_strconcat (previous_ids[i], new_suffix, NULL);
+              if (!g_hash_table_contains (seen, previous_desktop))
+                {
+                  g_hash_table_insert (seen, previous_desktop, previous_desktop);
+                  g_ptr_array_add (merged, g_steal_pointer (&previous_desktop));
+                }
+            }
+
+          if (merged->len > 0)
+            {
+              g_ptr_array_add (merged, NULL);
+              g_key_file_set_string_list (keyfile,
+                                          G_KEY_FILE_DESKTOP_GROUP,
+                                          X_FLATPAK_RENAMED_FROM,
+                                          (const char * const *) merged->pdata,
+                                          merged->len - 1);
+            }
+        }
     }
 
   groups = g_key_file_get_groups (keyfile, NULL);
@@ -5874,16 +5937,17 @@ out:
 }
 
 static gboolean
-rewrite_export_dir (const char     *app,
-                    const char     *branch,
-                    const char     *arch,
-                    GKeyFile       *metadata,
-                    FlatpakContext *context,
-                    int             source_parent_fd,
-                    const char     *source_name,
-                    const char     *source_path,
-                    GCancellable   *cancellable,
-                    GError        **error)
+rewrite_export_dir (const char         *app,
+                    const char         *branch,
+                    const char         *arch,
+                    GKeyFile           *metadata,
+                    const char * const *previous_ids,
+                    FlatpakContext     *context,
+                    int                 source_parent_fd,
+                    const char         *source_name,
+                    const char         *source_path,
+                    GCancellable       *cancellable,
+                    GError            **error)
 {
   gboolean ret = FALSE;
 
@@ -5936,7 +6000,7 @@ rewrite_export_dir (const char     *app,
         {
           g_autofree char *path = g_build_filename (source_path, dent->d_name, NULL);
 
-          if (!rewrite_export_dir (app, branch, arch, metadata, context,
+          if (!rewrite_export_dir (app, branch, arch, metadata, previous_ids, context,
                                    source_iter.fd, dent->d_name,
                                    path, cancellable, error))
             goto out;
@@ -5979,7 +6043,7 @@ rewrite_export_dir (const char     *app,
           if (g_str_has_suffix (dent->d_name, ".desktop") ||
               g_str_has_suffix (dent->d_name, ".service"))
             {
-              if (!export_desktop_file (app, branch, arch, metadata,
+              if (!export_desktop_file (app, branch, arch, metadata, previous_ids,
                                         source_iter.fd, dent->d_name, &stbuf, &new_name, cancellable, error))
                 goto out;
             }
@@ -6032,13 +6096,14 @@ out:
 }
 
 static gboolean
-flatpak_rewrite_export_dir (const char   *app,
-                            const char   *branch,
-                            const char   *arch,
-                            GKeyFile     *metadata,
-                            GFile        *source,
-                            GCancellable *cancellable,
-                            GError      **error)
+flatpak_rewrite_export_dir (const char         *app,
+                            const char         *branch,
+                            const char         *arch,
+                            GKeyFile           *metadata,
+                            const char * const *previous_ids,
+                            GFile              *source,
+                            GCancellable       *cancellable,
+                            GError            **error)
 {
   gboolean ret = FALSE;
 
@@ -6063,7 +6128,7 @@ flatpak_rewrite_export_dir (const char   *app,
     return FALSE;
 
   /* The fds are closed by this call */
-  if (!rewrite_export_dir (app, branch, arch, metadata, context,
+  if (!rewrite_export_dir (app, branch, arch, metadata, previous_ids, context,
                            parentfd, name, source_path,
                            cancellable, error))
     goto out;
@@ -6615,6 +6680,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *metadata_contents = NULL;
   g_autofree char *application_runtime = NULL;
   gboolean is_app;
+  g_autofree const char **previous_ids = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -6896,6 +6962,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                 G_FILE_CREATE_REPLACE_DESTINATION, NULL, cancellable, error))
     return TRUE;
 
+  if (old_deploy_data)
+    previous_ids = flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL);
 
   keyfile = g_key_file_new ();
   metadata = g_file_get_child (checkoutdir, "metadata");
@@ -6977,7 +7045,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
         return FALSE;
 
       if (!flatpak_rewrite_export_dir (ref_parts[1], ref_parts[3], ref_parts[2],
-                                       keyfile, export,
+                                       keyfile, previous_ids, export,
                                        cancellable,
                                        error))
         return FALSE;
@@ -7009,13 +7077,9 @@ flatpak_dir_deploy (FlatpakDir          *self,
   if (application_runtime)
     g_variant_builder_add (&metadata_builder, "{s@v}", "runtime",
                            g_variant_new_variant (g_variant_new_string (application_runtime)));
-  if (old_deploy_data)
-    {
-      g_autofree const char **previous_ids = flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL);
-      if (previous_ids)
-        g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
-                               g_variant_new_variant (g_variant_new_strv ((const char * const *) previous_ids, -1)));
-    }
+  if (previous_ids)
+    g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
+                           g_variant_new_variant (g_variant_new_strv ((const char * const *) previous_ids, -1)));
 
   deploy_data = flatpak_dir_new_deploy_data (origin,
                                              checksum,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5775,13 +5775,13 @@ export_desktop_file (const char   *app,
       if (tags != NULL)
         {
           g_key_file_set_string_list (keyfile,
-                                      "Desktop Entry",
+                                      G_KEY_FILE_DESKTOP_GROUP,
                                       "X-Flatpak-Tags",
                                       (const char * const *) tags, length);
         }
 
       /* Add a marker so consumers can easily find out that this launches a sandbox */
-      g_key_file_set_string (keyfile, "Desktop Entry", "X-Flatpak", app);
+      g_key_file_set_string (keyfile, G_KEY_FILE_DESKTOP_GROUP, "X-Flatpak", app);
     }
 
   groups = g_key_file_get_groups (keyfile, NULL);

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -44,6 +44,16 @@ Exec=hello.sh
 Icon=$APP_ID
 MimeType=x-test/Hello;
 EOF
+cat > ${DIR}/files/share/applications/org.test.Hello.Again.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Hello Again
+Exec=hello.sh --again
+Icon=$APP_ID
+MimeType=x-test/Hello;
+X-Flatpak-RenamedFrom=hello-again.desktop;
+EOF
 
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -768,6 +768,189 @@ test_install_launch_uninstall (void)
 static void update_test_app (void);
 static void update_repo (void);
 
+static const char *
+flatpak_deploy_data_get_origin (GVariant *deploy_data)
+{
+  const char *origin;
+
+  g_variant_get_child (deploy_data, 0, "&s", &origin);
+  return origin;
+}
+
+static const char *
+flatpak_deploy_data_get_commit (GVariant *deploy_data)
+{
+  const char *commit;
+
+  g_variant_get_child (deploy_data, 1, "&s", &commit);
+  return commit;
+}
+
+static const char *
+flatpak_deploy_data_get_runtime (GVariant *deploy_data)
+{
+  g_autoptr(GVariant) metadata = g_variant_get_child_value (deploy_data, 4);
+  const char *runtime = NULL;
+
+  g_variant_lookup (metadata, "runtime", "&s", &runtime);
+
+  return runtime;
+}
+
+/**
+ * flatpak_deploy_data_get_subpaths:
+ *
+ * Returns: (array length=length zero-terminated=1) (transfer container): an array of constant strings
+ **/
+static const char **
+flatpak_deploy_data_get_subpaths (GVariant *deploy_data)
+{
+  const char **subpaths;
+
+  g_variant_get_child (deploy_data, 2, "^a&s", &subpaths);
+  return subpaths;
+}
+
+static guint64
+flatpak_deploy_data_get_installed_size (GVariant *deploy_data)
+{
+  guint64 size;
+
+  g_variant_get_child (deploy_data, 3, "t", &size);
+  return GUINT64_FROM_BE (size);
+}
+
+static GVariant *
+flatpak_dir_new_deploy_data (const char *origin,
+                             const char *commit,
+                             char      **subpaths,
+                             guint64     installed_size,
+                             GVariant   *metadata)
+{
+  char *empty_subpaths[] = {NULL};
+  GVariantBuilder builder;
+
+  if (metadata == NULL)
+    {
+      g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
+      metadata = g_variant_builder_end (&builder);
+    }
+
+  return g_variant_ref_sink (g_variant_new ("(ss^ast@a{sv})",
+                                            origin,
+                                            commit,
+                                            subpaths ? subpaths : empty_subpaths,
+                                            GUINT64_TO_BE (installed_size),
+                                            metadata));
+}
+
+#define FLATPAK_DEPLOY_DATA_GVARIANT_STRING "(ssasta{sv})"
+#define FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT G_VARIANT_TYPE (FLATPAK_DEPLOY_DATA_GVARIANT_STRING)
+
+static GVariant *
+flatpak_load_deploy_data (GFile        *deploy_dir)
+{
+  g_autoptr(GFile) data_file = NULL;
+  g_autoptr(GError) error = NULL;
+  char *data = NULL;
+  gsize data_size;
+
+  data_file = g_file_get_child (deploy_dir, "deploy");
+  g_file_load_contents (data_file, NULL, &data, &data_size, NULL, &error);
+  g_assert_no_error (error);
+
+  return g_variant_ref_sink (g_variant_new_from_data (FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT,
+                                                      data, data_size,
+                                                      FALSE, g_free, data));
+}
+
+static gboolean
+flatpak_variant_save (GFile        *dest,
+                      GVariant     *variant,
+                      GCancellable *cancellable,
+                      GError      **error)
+{
+  g_autoptr(GOutputStream) out = NULL;
+  gsize bytes_written;
+
+  out = (GOutputStream *) g_file_replace (dest, NULL, FALSE,
+                                          G_FILE_CREATE_REPLACE_DESTINATION,
+                                          cancellable, error);
+  if (out == NULL)
+    return FALSE;
+
+  if (!g_output_stream_write_all (out,
+                                  g_variant_get_data (variant),
+                                  g_variant_get_size (variant),
+                                  &bytes_written,
+                                  cancellable,
+                                  error))
+    return FALSE;
+
+  if (!g_output_stream_close (out, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+mangle_deploy_file (FlatpakInstalledRef *ref)
+{
+  g_autoptr(GFile) dir = NULL;
+  g_autoptr(GVariant) data = NULL;
+  g_autoptr(GVariant) new_data = NULL;
+  g_autoptr(GFile) deploy_data_file = NULL;
+  GVariantBuilder metadata_builder;
+  g_autoptr(GError) error = NULL;
+  const char * const previous_ids[] = { "net.example.Goodbye", NULL };
+
+  dir = g_file_new_for_path (flatpak_installed_ref_get_deploy_dir (ref));
+  data = flatpak_load_deploy_data (dir);
+
+  g_variant_builder_init (&metadata_builder, G_VARIANT_TYPE ("a{sv}"));
+  g_variant_builder_add (&metadata_builder, "{s@v}", "runtime",
+                         g_variant_new_variant (g_variant_new_string (flatpak_deploy_data_get_runtime (data))));
+  g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
+                         g_variant_new_variant (g_variant_new_strv (previous_ids, -1)));
+
+  new_data = flatpak_dir_new_deploy_data (flatpak_deploy_data_get_origin (data),
+                                          flatpak_deploy_data_get_commit (data),
+                                          (char **) flatpak_deploy_data_get_subpaths (data),
+                                          flatpak_deploy_data_get_installed_size (data),
+                                          g_variant_builder_end (&metadata_builder));
+
+  deploy_data_file = g_file_get_child (dir, "deploy");
+  flatpak_variant_save (deploy_data_file, new_data, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+check_desktop_file (FlatpakInstalledRef *ref,
+                    const char          *file,
+                    const char          *expected_renamed_from)
+{
+  g_autofree char *path = g_build_path (G_DIR_SEPARATOR_S,
+                                        flatpak_installed_ref_get_deploy_dir (ref),
+                                        "export",
+                                        "share",
+                                        "applications",
+                                        file,
+                                        NULL);
+  g_autoptr(GKeyFile) kf = g_key_file_new ();
+  g_autofree char *renamed_from = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_key_file_load_from_file (kf, path, G_KEY_FILE_NONE, &error);
+  g_assert_no_error (error);
+
+  renamed_from = g_key_file_get_value (kf,
+                                       G_KEY_FILE_DESKTOP_GROUP,
+                                       "X-Flatpak-RenamedFrom",
+                                       &error);
+  g_assert_no_error (error);
+  g_assert_cmpstr (renamed_from, ==, expected_renamed_from);
+}
+
 static void
 test_list_updates (void)
 {
@@ -777,6 +960,7 @@ test_list_updates (void)
   g_autoptr(FlatpakInstalledRef) ref = NULL;
   g_autoptr(FlatpakInstalledRef) runtime_ref = NULL;
   FlatpakInstalledRef *update_ref = NULL;
+  g_autoptr(FlatpakInstalledRef) updated_ref = NULL;
   gboolean res;
 
   inst = flatpak_installation_new_user (NULL, &error);
@@ -801,6 +985,9 @@ test_list_updates (void)
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_INSTALLED_REF (ref));
 
+  /* Add a previous-id to the deploy file */
+  mangle_deploy_file (ref);
+
   /* Update the test app and list the update */
   update_test_app ();
   update_repo ();
@@ -816,6 +1003,23 @@ test_list_updates (void)
   update_ref = g_ptr_array_index (refs, 0);
   g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Hello");
   g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_APP);
+
+  /* Install the new update */
+  updated_ref = flatpak_installation_update (inst,
+                                             FLATPAK_UPDATE_FLAGS_NONE,
+                                             FLATPAK_REF_KIND_APP,
+                                             "org.test.Hello",
+                                             NULL, NULL, NULL, NULL, NULL,
+                                             &error);
+  g_assert_no_error (error);
+  g_assert (FLATPAK_IS_INSTALLED_REF (updated_ref));
+
+  check_desktop_file (updated_ref,
+                      "org.test.Hello.desktop",
+                      "net.example.Goodbye.desktop;");
+  check_desktop_file (updated_ref,
+                      "org.test.Hello.Again.desktop",
+                      "hello-again.desktop;net.example.Goodbye.Again.desktop;");
 
   /* Uninstall the runtime and app */
   res = flatpak_installation_uninstall (inst,


### PR DESCRIPTION
When migrating an installed app from eos-apps to Flathub, it may have had a
different app ID (com.example.App) in eos-apps to the Flathub ID
(net.example.app). The migration logic arranges for previous-ids to be set
in the deploy file, and flatpak-dir.c preserves this across app updates.

A user may have the app on their desktop or pinned to the taskbar under its
old ID, and the Shell uses X-Flatpak-RenamedFrom to update these to the new
ID. The migration logic arranges for the old ID to be added to
X-Flatpak-RenamedFrom at migration time; we need to also preserve this
across app updates.

Note that the Flathub version of the app may well have its own entries in
X-Flatpak-RenamedFrom. It is unlikely that these will overlap with ours,
but for neatness we take care to avoid adding duplicates.

I'm not very happy about the test case, which copy-pastes a lot of internal code from flatpak-dir.c to mess with the deploy file. It could be made shorter, but I have not had time.
https://phabricator.endlessm.com/T23845