### PR TITLE
Replace xa.collection-id with ostree.deploy-collection-id

### DIFF
--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -41,7 +41,7 @@ print_info (GVariant *meta)
   const char *collection_id;
   const char *default_branch;
   const char *redirect_url;
-  const char *redirect_collection_id;
+  const char *deploy_collection_id;
   g_autoptr(GVariant) gpg_keys = NULL;
 
   if (g_variant_lookup (meta, "xa.title", "&s", &title))
@@ -56,8 +56,13 @@ print_info (GVariant *meta)
   if (g_variant_lookup (meta, "xa.redirect-url", "&s", &redirect_url))
     g_print (_("Redirect URL: %s\n"), redirect_url);
 
-  if (g_variant_lookup (meta, "xa.collection-id", "&s", &redirect_collection_id))
-    g_print (_("Redirect collection ID: %s\n"), redirect_collection_id);
+/* FIXME: Remove this check when we depend on ostree 2018.9 */
+#ifndef OSTREE_META_KEY_DEPLOY_COLLECTION_ID
+#define OSTREE_META_KEY_DEPLOY_COLLECTION_ID "ostree.deploy-collection-id"
+#endif
+
+  if (g_variant_lookup (meta, OSTREE_META_KEY_DEPLOY_COLLECTION_ID, "&s", &deploy_collection_id))
+    g_print (_("Deploy collection ID: %s\n"), deploy_collection_id);
 
   if ((gpg_keys = g_variant_lookup_value (meta, "xa.gpg-keys", G_VARIANT_TYPE_BYTESTRING)) != NULL)
     {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11515,6 +11515,11 @@ flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *self,
                                                    GCancellable       *cancellable,
                                                    GError            **error)
 {
+/* FIXME: Remove this check when we depend on ostree 2018.9 */
+#ifndef OSTREE_META_KEY_DEPLOY_COLLECTION_ID
+#define OSTREE_META_KEY_DEPLOY_COLLECTION_ID "ostree.deploy-collection-id"
+#endif
+
   /* We only support those configuration parameters that can
      be set in the server when building the repo (see the
      flatpak_repo_set_* () family of functions) */
@@ -11523,7 +11528,7 @@ flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *self,
     "xa.default-branch",
     "xa.gpg-keys",
     "xa.redirect-url",
-    "xa.collection-id",
+    OSTREE_META_KEY_DEPLOY_COLLECTION_ID,
     NULL
   };
 
@@ -11566,7 +11571,7 @@ flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *self,
                     {
                       if (strcmp (key, "xa.redirect-url") == 0)
                         g_ptr_array_add (updated_params, g_strdup ("url"));
-                      else if (strcmp (key, "xa.collection-id") == 0)
+                      else if (strcmp (key, OSTREE_META_KEY_DEPLOY_COLLECTION_ID) == 0)
                         g_ptr_array_add (updated_params, g_strdup ("collection-id"));
                       else
                         g_ptr_array_add (updated_params, g_strdup (key));

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2950,11 +2950,12 @@ populate_commit_data_cache (GVariant   *metadata,
  * but kept for backwards compatibility).
  *
  * Note that there are two keys for the collection ID: collection-id, and
- * xa.collection-id. If a client does not currently have a collection ID configured
- * for this remote, it will *only* update its configuration from xa.collection-id.
- * This allows phased deployment of collection-based repositories. Clients will
- * only update their configuration from an unset to a set collection ID once
- * (otherwise the security properties of collection IDs are broken). */
+ * ostree.deploy-collection-id. If a client does not currently have a
+ * collection ID configured for this remote, it will *only* update its
+ * configuration from ostree.deploy-collection-id.  This allows phased
+ * deployment of collection-based repositories. Clients will only update their
+ * configuration from an unset to a set collection ID once (otherwise the
+ * security properties of collection IDs are broken). */
 gboolean
 flatpak_repo_update (OstreeRepo   *repo,
                      const char  **gpg_key_ids,
@@ -3011,8 +3012,13 @@ flatpak_repo_update (OstreeRepo   *repo,
     g_variant_builder_add (&builder, "{sv}", "xa.default-branch",
                            g_variant_new_string (default_branch));
 
+/* FIXME: Remove this check when we depend on ostree 2018.9 */
+#ifndef OSTREE_META_KEY_DEPLOY_COLLECTION_ID
+#define OSTREE_META_KEY_DEPLOY_COLLECTION_ID "ostree.deploy-collection-id"
+#endif
+
   if (deploy_collection_id && collection_id != NULL)
-    g_variant_builder_add (&builder, "{sv}", "xa.collection-id",
+    g_variant_builder_add (&builder, "{sv}", OSTREE_META_KEY_DEPLOY_COLLECTION_ID,
                            g_variant_new_string (collection_id));
   else if (deploy_collection_id)
     g_debug ("Ignoring deploy-collection-id=true because no collection ID is set.");

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -86,10 +86,10 @@ echo "ok 2 update repo config to deploy collection ID"
 #for ref in app/org.test.App/x86_64/master app/org.test.Hello/x86_64/master appstream/x86_64 ostree-metadata runtime/org.test.Platform/x86_64/master; do
 #  ostree --repo=repos/test refs --collections --create=org.test.Collection:$ref $ref
 #done
-ostree --repo=repos/test summary --update --add-metadata="xa.collection-id='net.malicious.NewCollection'"
+ostree --repo=repos/test summary --update --add-metadata="ostree.deploy-collection-id='net.malicious.NewCollection'"
 ${FLATPAK} ${U} update org.test.App master
 
 assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org.test.Collection$'
 assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id=net.malicious.NewCollection$'
 
-echo "ok 3 update repo config to with different collection ID"
+echo "ok 3 update repo config with different collection ID"


### PR DESCRIPTION
Currently Flatpak reads a repo metadata key called "xa.collection-id" to
decide whether to configure a collection ID on a remote. This commit
drops support for xa.collection-id and replaces it with
ostree.deploy-collection-id, which is a key defined by OSTree but so far
only implemented here.

The reason for the change is so that collection IDs can only be deployed
to users running recent versions of Flatpak and OSTree. The current
situation is that Endless wants to deploy collection IDs (and therefore
support for doing USB updates) to users, but servers such as Flathub
can't safely set xa.collection-id in their metadata, because many users
are still using old versions of Flatpak and OSTree[1] which would hit
various bugs[2][3][4] on the P2P code paths that are enabled by
collection IDs. Defining a new key means that only users running
recent (as-yet-unreleased) versions of Flatpak and OSTree will pay
attention to it and deploy the collection ID, leaving the users on old
versions unaffected.

The reason this metadata key is being defined at the level of OSTree
instead of Flatpak, is that OSTree may want to implement it in the
future.

The functionality of deploying a collection ID by setting the
"deploy-collection-id" key in the config on the server side (which in
turn causes ostree.deploy-collection-id to be set) is already covered by
the unit tests in test-update-remote-configuration.sh; this commit just
tweaks them to use the new key.

Another solution I proposed to this problem was to have a key
"eos.collection-id" which would only be understood by the Endless fork
of Flatpak, and use that temporarily until enough people are running
recent versions of Flatpak, at which point "xa.collection-id" can be
used. But this solution (abandoning xa.collection-id upstream) allows us
to avoid that migration step and leave users on old versions of Flatpak
completely unaffected.

[1] https://ahayzen.com/direct/flathub.html#downloadsbyflatpakstacked
[2] https://github.com/ostreedev/ostree/commit/e4e6d85ea
[3] https://github.com/flatpak/flatpak/commit/5813639f
[4] https://github.com/flatpak/flatpak/commit/5b21a5b7