### PR TITLE
create-usb: don't generate summary file

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -356,13 +356,6 @@ ostree_create_usb (GOptionContext *context,
     glnx_console_unlock (&console);
   }
 
-  /* Ensure a summary file is present to make it easier to look up commit checksums. */
-  /* FIXME: It should be possible to work without this, but find_remotes_cb() in
-   * ostree-repo-pull.c currently assumes a summary file (signed or unsigned) is
-   * present. */
-  if (!ostree_repo_regenerate_summary (dest_repo, NULL, cancellable, error))
-    return FALSE;
-
   /* Add the symlinks .ostree/repos.d/@symlink_name → @dest_repo_path, unless
    * the @dest_repo_path is a well-known one like ostree/repo, in which case no
    * symlink is necessary; #OstreeRepoFinderMount always looks there. */


### PR DESCRIPTION
Generating the summary requires acquiring an exclusive lock on the
OSTree repository which risks this process failing if another process,
like `ostree commit` or `ostree prune`, holds an exclusive lock for
longer than OSTree's core.lock-timeout-secs config option (which
defaults to only 30 seconds which is not always sufficient).

In testing directly and with Gnome Software calling this script to copy
the OS and dependencies to USB, this step seems to be unnecessary, so
we're best off skipping it.

https://phabricator.endlessm.com/T23422