### PR TITLE
create-usb: Avoid updating the source repo summary

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -741,10 +741,6 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
       }
   }
 
-  /* Update the summary in the repo; otherwise ostree_create_usb() will fail */
-  if (!flatpak_dir_update_summary (dir, cancellable, error))
-    return FALSE;
-
   /* Now use code copied from `ostree create-usb` to do the actual copying. We
    * can't just call out to `ostree` because (a) flatpak doesn't have a
    * dependency on the ostree command line tools and (b) we need to only pull


### PR DESCRIPTION
This commit removes the call to flatpak_dir_update_summary() in the
create-usb implementation. It turns out that libostree does not rely on
a summary being present when a pull is local (meaning it uses a file://
URI). I'm not sure where I got the idea that create-usb depends on a
summary in the source repo. I went back to the first commit that
introduced the "ostree create-usb" command and even using that a summary
isn't required, so it seems unlikely that this changed recently.

One important benefit of removing the summary update is that currently
summary generation takes an exclusive lock, and we've seen on Endless
the attempt to acquire that lock time out (possibly due to a prune
happening in another process).

We could also remove the system-helper method UpdateSummary since it
doesn't have any users after this commit, but maybe someone will need it
in the future, and technically removing it would be an API break.

https://phabricator.endlessm.com/T23422