### PR TITLE
flatpak-run: Add parental controls support for filtering apps (Debian changes)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+flatpak (1.0.0-0endless2) unstable; urgency=medium
+
+  * Add parental controls support to flatpak-run
+    - Adds a new libeos-parental-controls dependency
+
+ -- Philip Withnall <withnall@endlessm.com>  Fri, 12 Oct 2018 18:07:00 +1300
+
 flatpak (1.0.0-0endless1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Build-Depends:
  libcap-dev,
  libdw-dev,
  libelf-dev,
+ libeos-parental-controls-0-dev,
  libgirepository1.0-dev,
  libglib2.0-dev (>= 2.44),
  libgpgme-dev (>= 1.1.8),


### PR DESCRIPTION
https://phabricator.endlessm.com/T24020

See https://github.com/endlessm/flatpak/pull/128 for the master changes.