### PR TITLE
dir: Allow app filter to disallow app installation entirely

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7726,6 +7726,8 @@ flatpak_dir_install (FlatpakDir          *self,
 
       AsContentRating *rating = appstream_get_latest_content_rating (app);
 
+      if (!epc_app_filter_is_app_installation_allowed (app_filter))
+        return flatpak_fail (error, _("Current user is not allowed to install apps"));
       if (!appstream_check_rating (rating, app_filter))
         return flatpak_fail (error,
                              /* Translators: The placeholder is for an app ref. */


### PR DESCRIPTION
This is independent from the app-install polkit action, which determines
whether an unprivileged user may install an app system-wide. Being
stored in accountsservice, the new boolean is also easier to set
per-user without having to programmatically write a polkit JS policy
file which handles multiple users (and parse it back again).

It overrides the OARS values.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24457