### PR TITLE
system-helper: Don’t try and get parental controls for non-apps/runtimes

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1139,6 +1139,11 @@ authorize_deploy_add_polkit_details (const gchar    *installation,
   g_autoptr(AutoPolkitSubject) subject_process = NULL;
   gint subject_uid;
 
+  /* The ostree-metadata and appstream/* branches should not have any parental
+   * controls restrictions. */
+  if (!g_str_has_prefix (ref, "app/") && !g_str_has_prefix (ref, "runtime/"))
+    return TRUE;
+
   g_debug ("Getting parental controls details for %s from %s", ref, origin);
 
   system = dir_get_system (installation, error);


### PR DESCRIPTION
This includes the ostree-metadata and appstream/* refs.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24457