### PR TITLE
Revert "Stop linking libflatpak against listappstream-glib"

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -133,6 +133,7 @@ libflatpak_common_la_SOURCES = \
 libflatpak_common_la_CFLAGS = \
 	-DFLATPAK_COMPILATION \
 	$(AM_CFLAGS) \
+	$(APPSTREAM_GLIB_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(HIDDEN_VISIBILITY_CFLAGS) \
 	$(OSTREE_CFLAGS) \


### PR DESCRIPTION
This reverts commit f9c6a769ef30a3a33038ec91f080197a0bf418a5.

This is necessary because we reverted the upstream commit 9dff4bbb8 in
order to support the parental controls feature.

https://phabricator.endlessm.com/T25194