### PR TITLE
Backport security fix from Flatpak 1.0.7

### DIFF
--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -44,6 +44,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_SANDBOX            = (1 << 14),
   FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL = (1 << 15),
   FLATPAK_RUN_FLAG_BLUETOOTH          = (1 << 16),
+  FLATPAK_RUN_FLAG_NO_PROC            = (1 << 19),
 } FlatpakRunFlags;
 
 typedef struct FlatpakDir          FlatpakDir;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6596,7 +6596,7 @@ apply_extra_data (FlatpakDir   *self,
                           NULL);
 
   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, NULL, runtime_ref_parts[2],
-                                    FLATPAK_RUN_FLAG_NO_SESSION_HELPER,
+                                    FLATPAK_RUN_FLAG_NO_SESSION_HELPER | FLATPAK_RUN_FLAG_NO_PROC,
                                     error))
     return FALSE;
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2340,9 +2340,13 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
     "# Disable user pkcs11 config, because the host modules don't work in the runtime\n"
     "user-config: none\n";
 
+  if ((flags & FLATPAK_RUN_FLAG_NO_PROC) == 0)
+    flatpak_bwrap_add_args (bwrap,
+                            "--proc", "/proc",
+                            NULL);
+
   flatpak_bwrap_add_args (bwrap,
                           "--unshare-pid",
-                          "--proc", "/proc",
                           "--dir", "/tmp",
                           "--dir", "/var/tmp",
                           "--dir", "/run/host",


### PR DESCRIPTION
Upstream commit message:

> Don't expose /proc when running apply_extra
> 
> As shown by CVE-2019-5736, it is sometimes possible for the sandbox
> app to access outside files using /proc/self/exe. This is not
> typically an issue for flatpak as the sandbox runs as the user which
> has no permissions to e.g. modify the host files.
> 
> However, when installing apps using extra-data into the system repo
> we *do* actually run a sandbox as root. So, in this case we disable mounting
> /proc in the sandbox, which will neuter attacks like this.

Modified to fix a minor conflict in the FlatpakRunFlags hunk due to FLATPAK_RUN_FLAG_CANBUS not being present in our 1.0.x branch. This is the eos3.5 counterpart to https://github.com/endlessm/flatpak/pull/148.

https://phabricator.endlessm.com/T25408