### PR TITLE
Backports from 1.3.1

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -206,7 +206,9 @@ install_from (FlatpakDir *dir,
   if (g_str_has_prefix (filename, "http:") ||
       g_str_has_prefix (filename, "https:"))
     {
-      file_data = download_uri (filename, error);
+      g_autoptr(SoupSession) soup_session = NULL;
+      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
+      file_data = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, cancellable, error);
       if (file_data == NULL)
         {
           g_prefix_error (error, "Can't load uri %s: ", filename);

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -214,7 +214,7 @@ print_table_for_refs (gboolean print_apps,
           parts = g_strsplit (ref, "/", -1);
           partial_ref = strchr (ref, '/') + 1;
 
-          if (arch != NULL && strcmp (arch, parts[1]) != 0)
+          if (arch != NULL && strcmp (arch, parts[2]) != 0)
             continue;
 
           deploy = flatpak_dir_load_deployed (dir, ref, NULL, cancellable, NULL);

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -183,8 +183,10 @@ load_options (const char *filename,
     {
       const char *options_data;
       gsize options_size;
+      g_autoptr(SoupSession) soup_session = NULL;
 
-      bytes = download_uri (filename, &error);
+      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
+      bytes = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, NULL, &error);
 
       if (bytes == NULL)
         {

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -92,66 +92,6 @@ looks_like_branch (const char *branch)
   return TRUE;
 }
 
-static SoupSession *
-get_soup_session (void)
-{
-  static SoupSession *soup_session = NULL;
-
-  if (soup_session == NULL)
-    {
-      const char *http_proxy;
-
-      soup_session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, "flatpak-builder ",
-                                                    SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
-                                                    SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
-                                                    SOUP_SESSION_TIMEOUT, 60,
-                                                    SOUP_SESSION_IDLE_TIMEOUT, 60,
-                                                    NULL);
-      http_proxy = g_getenv ("http_proxy");
-      if (http_proxy)
-        {
-          g_autoptr(SoupURI) proxy_uri = soup_uri_new (http_proxy);
-          if (!proxy_uri)
-            g_warning ("Invalid proxy URI '%s'", http_proxy);
-          else
-            g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
-        }
-    }
-
-  return soup_session;
-}
-
-GBytes *
-download_uri (const char *url,
-              GError    **error)
-{
-  SoupSession *session;
-
-  g_autoptr(SoupRequest) req = NULL;
-  g_autoptr(GInputStream) input = NULL;
-  g_autoptr(GOutputStream) out = NULL;
-
-  session = get_soup_session ();
-
-  req = soup_session_request (session, url, error);
-  if (req == NULL)
-    return NULL;
-
-  input = soup_request_send (req, NULL, error);
-  if (input == NULL)
-    return NULL;
-
-  out = g_memory_output_stream_new_resizable ();
-  if (!g_output_stream_splice (out,
-                               input,
-                               G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET | G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
-                               NULL,
-                               error))
-    return NULL;
-
-  return g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (out));
-}
-
 FlatpakDir *
 flatpak_find_installed_pref (const char *pref, FlatpakKinds kinds, const char *default_arch, const char *default_branch,
                              gboolean search_all, gboolean search_user, gboolean search_system, char **search_installations,

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -51,8 +51,6 @@ RemoteDirPair * remote_dir_pair_new (const char *remote_name,
                                      FlatpakDir *dir);
 
 gboolean    looks_like_branch (const char *branch);
-GBytes *    download_uri (const char *url,
-                          GError    **error);
 
 GBytes * flatpak_load_gpg_keys (char        **gpg_import,
                                 GCancellable *cancellable,

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -95,8 +95,8 @@ choose_remote_for_ref (FlatpakTransaction *transaction,
   else
     {
       flatpak_format_choices ((const char **)remotes,
-                              _("Required runtime for %s (%s) found in remotes: %s"),
-                              pref, runtime_ref, remotes[0]);
+                              _("Required runtime for %s (%s) found in remotes:"),
+                              pref, runtime_ref);
       chosen = flatpak_number_prompt (TRUE, 0, n_remotes, _("Which do you want to install (0 to abort)?"));
       chosen -= 1; /* convert from base-1 to base-0 (and -1 to abort) */
     }

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -653,7 +653,7 @@ get_xdg_user_dir_from_string (const char  *filesystem,
       if (config_key)
         *config_key = NULL;
       if (dir)
-        *dir = g_get_user_runtime_dir ();
+        *dir = flatpak_get_real_xdg_runtime_dir ();
       return TRUE;
     }
 
@@ -2087,8 +2087,9 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
 
   if (app_id_dir != NULL)
     {
+      g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
       g_autofree char *run_user_app_dst = g_strdup_printf ("/run/user/%d/app/%s", getuid (), app_id);
-      g_autofree char *run_user_app_src = g_build_filename (g_get_user_runtime_dir (), "app", app_id, NULL);
+      g_autofree char *run_user_app_src = g_build_filename (user_runtime_dir, "app", app_id, NULL);
 
       if (glnx_shutil_mkdir_p_at (AT_FDCWD,
                                   run_user_app_src,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4110,9 +4110,6 @@ ensure_soup_session (FlatpakDir *self)
 
       soup_session = flatpak_create_soup_session (PACKAGE_STRING);
 
-      if (g_getenv ("OSTREE_DEBUG_HTTP"))
-        soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
-
       g_once_init_leave (&self->soup_session, soup_session);
     }
 }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -578,13 +578,12 @@ flatpak_load_deploy_data (GFile        *deploy_dir,
                           GError      **error)
 {
   g_autoptr(GFile) data_file = NULL;
-  g_autoptr(GError) my_error = NULL;
   char *data = NULL;
   gsize data_size;
   g_autoptr(GVariant) deploy_data = NULL;
 
   data_file = g_file_get_child (deploy_dir, "deploy");
-  if (!g_file_load_contents (data_file, cancellable, &data, &data_size, NULL, &my_error))
+  if (!g_file_load_contents (data_file, cancellable, &data, &data_size, NULL, error))
     return NULL;
 
   deploy_data = g_variant_ref_sink (g_variant_new_from_data (FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -233,6 +233,7 @@ static gboolean
 flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
 {
   const char *wayland_display;
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
   g_autofree char *wayland_socket = NULL;
   g_autofree char *sandbox_wayland_socket = NULL;
   gboolean res = FALSE;
@@ -242,7 +243,7 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
   if (!wayland_display)
     wayland_display = "wayland-0";
 
-  wayland_socket = g_build_filename (g_get_user_runtime_dir (), wayland_display, NULL);
+  wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
   sandbox_wayland_socket = g_strdup_printf ("/run/user/%d/%s", getuid (), wayland_display);
 
   if (stat (wayland_socket, &statbuf) == 0 &&
@@ -399,12 +400,13 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap *bwrap)
 {
   g_autofree char *pulseaudio_server = flatpak_run_get_pulseaudio_server ();
   g_autofree char *pulseaudio_socket = NULL;
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
 
   if (pulseaudio_server)
     pulseaudio_socket = flatpak_run_parse_pulse_server (pulseaudio_server);
 
   if (!pulseaudio_socket)
-    pulseaudio_socket = g_build_filename (g_get_user_runtime_dir (), "pulse/native", NULL);
+    pulseaudio_socket = g_build_filename (user_runtime_dir, "pulse/native", NULL);
 
   flatpak_bwrap_unset_env (bwrap, "PULSE_SERVER");
 
@@ -454,7 +456,8 @@ flatpak_run_add_journal_args (FlatpakBwrap *bwrap)
 static char *
 create_proxy_socket (char *template)
 {
-  g_autofree char *proxy_socket_dir = g_build_filename (g_get_user_runtime_dir (), ".dbus-proxy", NULL);
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+  g_autofree char *proxy_socket_dir = g_build_filename (user_runtime_dir, ".dbus-proxy", NULL);
   g_autofree char *proxy_socket = g_build_filename (proxy_socket_dir, template, NULL);
   int fd;
 
@@ -686,7 +689,7 @@ add_bwrap_wrapper (FlatpakBwrap *bwrap,
 
   g_auto(GLnxDirFdIterator) dir_iter = { 0 };
   struct dirent *dent;
-  g_autofree char *user_runtime_dir = realpath (g_get_user_runtime_dir (), NULL);
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
   g_autofree char *proxy_socket_dir = g_build_filename (user_runtime_dir, ".dbus-proxy/", NULL);
 
   app_info_fd = open (app_info_path, O_RDONLY | O_CLOEXEC);
@@ -1684,7 +1687,8 @@ flatpak_run_gc_ids (void)
 static char *
 flatpak_run_allocate_id (int *lock_fd_out)
 {
-  g_autofree char *base_dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", NULL);
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+  g_autofree char *base_dir = g_build_filename (user_runtime_dir, ".flatpak", NULL);
   int count;
 
   g_mkdir_with_parents (base_dir, 0755);
@@ -1938,12 +1942,13 @@ flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
   g_autofree char *instance_id_host_dir = NULL;
   g_autofree char *instance_id_sandbox_dir = NULL;
   g_autofree char *instance_id_lock_file = NULL;
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
 
   instance_id = flatpak_run_allocate_id (&lock_fd);
   if (instance_id == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Unable to allocate instance id"));
 
-  instance_id_host_dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", instance_id, NULL);
+  instance_id_host_dir = g_build_filename (user_runtime_dir, ".flatpak", instance_id, NULL);
   instance_id_sandbox_dir = g_strdup_printf ("/run/user/%d/.flatpak/%s", getuid (), instance_id);
   instance_id_lock_file = g_build_filename (instance_id_sandbox_dir, ".ref", NULL);
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2368,20 +2368,12 @@ remote_is_already_configured (FlatpakTransaction *self,
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
   g_autofree char *old_remote = NULL;
-  int i;
 
   old_remote = flatpak_dir_find_remote_by_uri (priv->dir, url, collection_id);
-  if (old_remote == NULL)
-    {
-      for (i = 0; i < priv->extra_dependency_dirs->len; i++)
-        {
-          FlatpakDir *dependency_dir = g_ptr_array_index (priv->extra_dependency_dirs, i);
 
-          old_remote = flatpak_dir_find_remote_by_uri (dependency_dir, url, collection_id);
-          if (old_remote != NULL)
-            break;
-        }
-    }
+  /* Note: we don't check priv->extra_dependency_dirs because the transaction
+   * can only operate on one installation so any install/update ops need to
+   * have a remote there. */
 
   return old_remote != NULL;
 }

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2361,37 +2361,6 @@ flatpak_transaction_get_installation (FlatpakTransaction *self)
   return g_object_ref (priv->installation);
 }
 
-
-static GBytes *
-download_uri (const char *url,
-              GError    **error)
-{
-  g_autoptr(SoupSession) session = NULL;
-  g_autoptr(SoupRequest) req = NULL;
-  g_autoptr(GInputStream) input = NULL;
-  g_autoptr(GOutputStream) out = NULL;
-
-  session = flatpak_create_soup_session (PACKAGE_STRING);
-
-  req = soup_session_request (session, url, error);
-  if (req == NULL)
-    return NULL;
-
-  input = soup_request_send (req, NULL, error);
-  if (input == NULL)
-    return NULL;
-
-  out = g_memory_output_stream_new_resizable ();
-  if (!g_output_stream_splice (out,
-                               input,
-                               G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET | G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
-                               NULL,
-                               error))
-    return NULL;
-
-  return g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (out));
-}
-
 static gboolean
 remote_is_already_configured (FlatpakTransaction *self,
                               const char         *url,
@@ -2476,7 +2445,11 @@ handle_suggested_remote_name (FlatpakTransaction *self, GKeyFile *keyfile, GErro
 }
 
 static gboolean
-handle_runtime_repo_deps (FlatpakTransaction *self, const char *id, const char *dep_url, GError **error)
+handle_runtime_repo_deps (FlatpakTransaction *self,
+                          const char         *id,
+                          const char         *dep_url,
+                          GCancellable       *cancellable,
+                          GError            **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
 
@@ -2492,6 +2465,7 @@ handle_runtime_repo_deps (FlatpakTransaction *self, const char *id, const char *
   g_autofree char *group = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autofree char *runtime_collection_id = NULL;
+  g_autoptr(SoupSession) soup_session = NULL;
   char *t;
   int i;
   gboolean res;
@@ -2499,7 +2473,11 @@ handle_runtime_repo_deps (FlatpakTransaction *self, const char *id, const char *
   if (priv->disable_deps)
     return TRUE;
 
-  dep_data = download_uri (dep_url, error);
+  if (!g_str_has_prefix (dep_url, "http:") && !g_str_has_prefix (dep_url, "https:"))
+    return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Flatpakrepo URL %s not HTTP or HTTPS"), dep_url);
+
+  soup_session = flatpak_create_soup_session (PACKAGE_STRING);
+  dep_data = flatpak_load_http_uri (soup_session, dep_url, 0, NULL, NULL, cancellable, error);
   if (dep_data == NULL)
     {
       g_prefix_error (error, "Can't load dependent file %s", dep_url);
@@ -2568,7 +2546,10 @@ handle_runtime_repo_deps (FlatpakTransaction *self, const char *id, const char *
 }
 
 static gboolean
-handle_runtime_repo_deps_from_keyfile (FlatpakTransaction *self, GKeyFile *keyfile, GError **error)
+handle_runtime_repo_deps_from_keyfile (FlatpakTransaction *self,
+                                       GKeyFile           *keyfile,
+                                       GCancellable       *cancellable,
+                                       GError            **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
   g_autofree char *dep_url = NULL;
@@ -2586,7 +2567,7 @@ handle_runtime_repo_deps_from_keyfile (FlatpakTransaction *self, GKeyFile *keyfi
   if (name == NULL)
     return TRUE;
 
-  return handle_runtime_repo_deps (self, name, dep_url, error);
+  return handle_runtime_repo_deps (self, name, dep_url, cancellable, error);
 }
 
 static gboolean
@@ -2607,7 +2588,7 @@ flatpak_transaction_resolve_flatpakrefs (FlatpakTransaction *self,
       if (!handle_suggested_remote_name (self, flatpakref, error))
         return FALSE;
 
-      if (!handle_runtime_repo_deps_from_keyfile (self, flatpakref, error))
+      if (!handle_runtime_repo_deps_from_keyfile (self, flatpakref, cancellable, error))
         return FALSE;
 
       if (!flatpak_dir_create_remote_for_ref_file (priv->dir, flatpakref, priv->default_arch,
@@ -2630,6 +2611,7 @@ flatpak_transaction_resolve_flatpakrefs (FlatpakTransaction *self,
 static gboolean
 handle_runtime_repo_deps_from_bundle (FlatpakTransaction *self,
                                       GFile              *file,
+                                      GCancellable       *cancellable,
                                       GError            **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
@@ -2658,7 +2640,7 @@ handle_runtime_repo_deps_from_bundle (FlatpakTransaction *self,
 
   ref_parts = g_strsplit (ref, "/", -1);
 
-  return handle_runtime_repo_deps (self, ref_parts[1], dep_url, error);
+  return handle_runtime_repo_deps (self, ref_parts[1], dep_url, cancellable, error);
 }
 
 static gboolean
@@ -2678,7 +2660,7 @@ flatpak_transaction_resolve_bundles (FlatpakTransaction *self,
       g_autofree char *metadata = NULL;
       gboolean created_remote;
 
-      if (!handle_runtime_repo_deps_from_bundle (self, data->file, error))
+      if (!handle_runtime_repo_deps_from_bundle (self, data->file, cancellable, error))
         return FALSE;
 
       if (!flatpak_dir_ensure_repo (priv->dir, cancellable, error))

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -507,6 +507,9 @@ flatpak_create_soup_session (const char *user_agent)
         g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
     }
 
+  if (g_getenv ("OSTREE_DEBUG_HTTP"))
+    soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
+
   return soup_session;
 }
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -89,6 +89,10 @@ void flatpak_debug2 (const char *format,
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);
 
+/* Sometimes this is /var/run which is a symlink, causing weird issues when we pass
+ * it as a path into the sandbox */
+char * flatpak_get_real_xdg_runtime_dir (void);
+
 gboolean  flatpak_has_path_prefix (const char *str,
                                    const char *prefix);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -223,6 +223,14 @@ flatpak_strcmp0_ptr (gconstpointer a,
   return g_strcmp0 (*(char * const *) a, *(char * const *) b);
 }
 
+/* Sometimes this is /var/run which is a symlink, causing weird issues when we pass
+ * it as a path into the sandbox */
+char *
+flatpak_get_real_xdg_runtime_dir (void)
+{
+  return realpath (g_get_user_runtime_dir (), NULL);
+}
+
 /* Compares if str has a specific path prefix. This differs
    from a regular prefix in two ways. First of all there may
    be multiple slashes separating the path elements, and

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -286,16 +286,22 @@
         <title>Examples</title>
 
         <para>
-            <command>$ flatpak install gnome org.gnome.gedit2</command>
+            <command>$ flatpak install gedit</command>
         </para>
         <para>
-            <command>$ flatpak --installation=default install gnome org.gnome.gedit2</command>
+            <command>$ flatpak install flathub org.gnome.gedit</command>
         </para>
         <para>
-            <command>$ flatpak --user install gnome org.gnome.gedit//3.22</command>
+            <command>$ flatpak --installation=default install flathub org.gnome.gedit</command>
         </para>
         <para>
-            <command>$ flatpak --user install https://sdk.gnome.org/gedit.flatpakref</command>
+            <command>$ flatpak --user install flathub org.gnome.gedit//3.30</command>
+        </para>
+        <para>
+            <command>$ flatpak --user install https://flathub.org/repo/appstream/org.gnome.gedit.flatpakref</command>
+        </para>
+        <para>
+            <command>$ flatpak --system install org.gnome.gedit.flatpakref</command>
         </para>
 
     </refsect1>

--- a/tests/httpcache.c
+++ b/tests/httpcache.c
@@ -3,7 +3,7 @@
 int
 main (int argc, char *argv[])
 {
-  SoupSession *session = flatpak_create_soup_session (PACKAGE_STRING);
+  g_autoptr(SoupSession) session = flatpak_create_soup_session (PACKAGE_STRING);
   GError *error = NULL;
   const char *url, *dest;
   int flags = 0;

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..27"
+echo "1..28"
 
 #Regular repo
 setup_repo
@@ -168,6 +168,14 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} != xyes ] ; then
 fi
 
 echo "ok missing remote name auto-corrects for install"
+
+port=$(cat httpd-port-main)
+if ${FLATPAK} ${U} install -y http://127.0.0.1:${port}/nonexistent.flatpakref 2> install-error-log; then
+    assert_not_reached "Should not be able to install a nonexistent flatpakref"
+fi
+assert_file_has_content install-error-log "Server returned status 404: Not Found"
+
+echo "ok install fails gracefully for 404 URLs"
 
 ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1145,7 +1145,7 @@ test_install_launch_uninstall (void)
 }
 
 static void update_test_app (void);
-static void update_repo (void);
+static void update_repo (const char *update_repo_name);
 
 static const char *
 flatpak_deploy_data_get_origin (GVariant *deploy_data)
@@ -1369,7 +1369,7 @@ test_list_updates (void)
 
   /* Update the test app and list the update */
   update_test_app ();
-  update_repo ();
+  update_repo ("test");
 
   /* Drop all in-memory summary caches so we can find the new update */
   flatpak_installation_drop_caches (inst, NULL, &error);
@@ -1491,41 +1491,35 @@ make_bundle (void)
 }
 
 static void
-make_test_runtime (void)
+make_test_runtime (const char *runtime_repo_name)
 {
   g_autofree char *arg0 = NULL;
+  g_autofree char *arg1 = NULL;
   char *argv[] = {
-    NULL, "repos/test", "org.test.Platform", "", NULL
+    NULL, NULL, "org.test.Platform", "", NULL
   };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);
+  arg1 = g_strdup_printf ("repos/%s", runtime_repo_name);
   argv[0] = arg0;
+  argv[1] = arg1;
   argv[3] = repo_collection_id;
 
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
 }
 
 static void
-make_test_app (void)
+make_test_app (const char *app_repo_name)
 {
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "repos/test", "", "", NULL };
+  g_autofree char *arg1 = NULL;
+  char *argv[] = { NULL, NULL, "", "", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
+  arg1 = g_strdup_printf ("repos/%s", app_repo_name);
   argv[0] = arg0;
+  argv[1] = arg1;
   argv[3] = repo_collection_id;
-
-  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
-}
-
-static void
-make_test_app2 (void)
-{
-  g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "repos/test-without-runtime", "", "", NULL };
-
-  arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
-  argv[0] = arg0;
 
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
 }
@@ -1544,53 +1538,33 @@ update_test_app (void)
 }
 
 static void
-update_repo (void)
+update_repo (const char *update_repo_name)
 {
-  char *argv[] = { "flatpak", "build-update-repo", "--gpg-homedir=", "--gpg-sign=", "repos/test", NULL };
-
+  g_autofree char *arg4 = NULL;
+  char *argv[] = { "flatpak", "build-update-repo", "--gpg-homedir=", "--gpg-sign=", NULL, NULL };
   g_auto(GStrv) gpgargs = NULL;
 
   gpgargs = g_strsplit (gpg_args, " ", 0);
+  arg4 = g_strdup_printf ("repos/%s", update_repo_name);
   argv[2] = gpgargs[0];
   argv[3] = gpgargs[1];
-  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
-}
+  argv[4] = arg4;
 
-static void
-update_repo2 (void)
-{
-  char *argv[] = { "flatpak", "build-update-repo", "--gpg-homedir=", "--gpg-sign=", "repos/test-without-runtime", NULL };
-
-  g_auto(GStrv) gpgargs = NULL;
-
-  gpgargs = g_strsplit (gpg_args, " ", 0);
-  argv[2] = gpgargs[0];
-  argv[3] = gpgargs[1];
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
 }
 
 static void
 launch_httpd (void)
 {
+  g_autoptr(GError) error = NULL;
+  g_autofree char *port = NULL;
+  g_autofree char *pid = NULL;
   g_autofree char *path = g_test_build_filename (G_TEST_DIST, "test-webserver.sh", NULL);
   char *argv[] = {path, "repos", NULL };
 
   /* The web server puts itself in the background, so we can't wait
    * for EOF on its stdout, stderr */
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_NO_CAPTURE);
-}
-
-static void
-add_remote (void)
-{
-  g_autoptr(GError) error = NULL;
-  char *argv[] = { "flatpak", "remote-add", "--user", "--gpg-import=", "--collection-id=", "name", "url", NULL };
-  g_autofree char *gpgimport = NULL;
-  g_autofree char *port = NULL;
-  g_autofree char *pid = NULL;
-  g_autofree char *collection_id_arg = NULL;
-
-  launch_httpd ();
 
   g_file_get_contents ("httpd-pid", &pid, NULL, &error);
   g_assert_no_error (error);
@@ -1605,31 +1579,85 @@ add_remote (void)
     port[strlen (port) - 1] = '\0';
 
   httpd_port = g_strdup (port);
+}
+
+static void
+_add_remote (const char *remote_repo_name,
+             gboolean    system)
+{
+  g_autoptr(GError) error = NULL;
+  char *argv[] = { "flatpak", "remote-add", NULL, "--gpg-import=", "--collection-id=", "name", "url", NULL };
+  g_autofree char *gpgimport = NULL;
+  g_autofree char *collection_id_arg = NULL;
+  g_autofree char *remote_name = NULL;
 
   gpgimport = g_strdup_printf ("--gpg-import=%s/pubring.gpg", gpg_homedir);
-  repo_url = g_strdup_printf ("http://127.0.0.1:%s/test", port);
+  repo_url = g_strdup_printf ("http://127.0.0.1:%s/%s", httpd_port, remote_repo_name);
   collection_id_arg = g_strdup_printf ("--collection-id=%s", repo_collection_id);
+  remote_name = g_strdup_printf ("%s-repo", remote_repo_name);
 
+  argv[2] = system ? "--system" : "--user";
   argv[3] = gpgimport;
   argv[4] = collection_id_arg;
-  argv[5] = (char *) repo_name;
+  argv[5] = remote_name;
   argv[6] = repo_url;
+
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
 }
 
 static void
-add_flatpakrepo (void)
+add_remote_system (const char *remote_repo_name)
+{
+  _add_remote (remote_repo_name, TRUE);
+}
+
+static void
+add_remote_user (const char *remote_repo_name)
+{
+  _add_remote (remote_repo_name, FALSE);
+}
+
+static void
+_remove_remote (const char *remote_repo_name,
+                gboolean    system)
+{
+  char *argv[] = { "flatpak", "remote-delete", NULL, "name", NULL };
+  g_autofree char *remote_name = NULL;
+
+  remote_name = g_strdup_printf ("%s-repo", remote_repo_name);
+  argv[2] = system ? "--system" : "--user";
+  argv[3] = remote_name;
+
+  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
+}
+
+static void
+remove_remote_system (const char *remote_repo_name)
+{
+  _remove_remote (remote_repo_name, TRUE);
+}
+
+static void
+remove_remote_user (const char *remote_repo_name)
+{
+  _remove_remote (remote_repo_name, FALSE);
+}
+
+static void
+add_flatpakrepo (const char *flatpakrepo_repo_name)
 {
   g_autofree char *data = NULL;
   g_autoptr(GError) error = NULL;
+  g_autofree char *file_path = NULL;
 
   data = g_strconcat ("[Flatpak Repo]\n"
                       "Version=1\n"
-                      "Url=http://127.0.0.1:", httpd_port, "/test\n"
+                      "Url=http://127.0.0.1:", httpd_port, "/", flatpakrepo_repo_name, "\n"
                       "DefaultBranch=master\n"
                       "Title=Test repo\n", NULL);
 
-  g_file_set_contents ("repos/test/test.flatpakrepo", data, -1, &error);
+  file_path = g_strdup_printf ("repos/%s/%s-repo.flatpakrepo", flatpakrepo_repo_name, flatpakrepo_repo_name);
+  g_file_set_contents (file_path, data, -1, &error);
   g_assert_no_error (error);
 }
 
@@ -1697,19 +1725,25 @@ setup_repo (void)
 {
   repo_collection_id = "com.example.Test";
 
-  make_test_runtime ();
-  make_test_app ();
-  update_repo ();
-  add_remote ();
-  add_flatpakrepo ();
+  make_test_runtime ("test");
+  make_test_app ("test");
+  update_repo ("test");
+  launch_httpd ();
+  add_remote_user ("test");
+  add_flatpakrepo ("test");
   configure_languages ();
 
   /* another copy of the same repo, with different url */
   symlink("test", "repos/copy-of-test");
 
   /* another repo, with only the app */
-  make_test_app2 ();
-  update_repo2 ();
+  make_test_app ("test-without-runtime");
+  update_repo ("test-without-runtime");
+
+  /* another repo, with only the runtime */
+  make_test_runtime ("test-runtime-only");
+  update_repo ("test-runtime-only");
+  add_flatpakrepo ("test-runtime-only");
 }
 
 static void
@@ -2474,7 +2508,7 @@ test_transaction_install_flatpakref (void)
                    "Url=http://127.0.0.1:", httpd_port, "/copy-of-test\n"
                    "IsRuntime=False\n"
                    "SuggestRemoteName=my-little-repo\n"
-                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test.flatpakrepo\n",
+                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test-repo.flatpakrepo\n",
                    NULL);
 
   data = g_bytes_new (s, strlen (s));
@@ -2512,6 +2546,121 @@ test_transaction_install_flatpakref (void)
   res = flatpak_transaction_run (transaction, NULL, &error);
   g_assert_no_error (error);
   g_assert_true (res);
+}
+
+static gboolean
+_is_remote_in_installation (FlatpakInstallation *installation,
+                            const char          *remote_repo_name)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GPtrArray) remotes = NULL;
+  g_autofree char *remote_name = NULL;
+
+  remotes = flatpak_installation_list_remotes (installation, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (remotes);
+
+  remote_name = g_strdup_printf ("%s-repo", remote_repo_name);
+  for (guint i = 0; i < remotes->len; ++i)
+    {
+      FlatpakRemote *remote = g_ptr_array_index (remotes, i);
+      if (g_strcmp0 (remote_name, flatpak_remote_get_name (remote)) == 0)
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+static void
+assert_remote_in_installation (FlatpakInstallation *installation,
+                               const char          *remote_repo_name)
+{
+  g_assert (_is_remote_in_installation (installation, remote_repo_name));
+}
+
+static void
+assert_remote_not_in_installation (FlatpakInstallation *installation,
+                                   const char          *remote_repo_name)
+{
+  g_assert (!_is_remote_in_installation (installation, remote_repo_name));
+}
+
+static gboolean
+add_new_remote3 (FlatpakTransaction *transaction,
+                 const char         *reason,
+                 const char         *from_id,
+                 const char         *suggested_name,
+                 const char         *url)
+{
+  return TRUE;
+}
+
+/* Test that installing a flatpakref causes both the origin remote and the
+ * runtime remote to be created, even if they already exist in another
+ * installation */
+static void
+test_transaction_flatpakref_remote_creation (void)
+{
+  g_autoptr(FlatpakInstallation) user_inst = NULL;
+  g_autoptr(FlatpakInstallation) system_inst = NULL;
+  g_autoptr(FlatpakTransaction) transaction = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(FlatpakRemoteRef) ref = NULL;
+  g_autofree char *s = NULL;
+  g_autoptr(GBytes) data = NULL;
+  gboolean res;
+
+  system_inst = flatpak_installation_new_system (NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (system_inst);
+
+  empty_installation (system_inst);
+
+  add_remote_system ("test-without-runtime");
+  add_remote_system ("test-runtime-only");
+
+  user_inst = flatpak_installation_new_user (NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (user_inst);
+
+  empty_installation (user_inst);
+
+  assert_remote_not_in_installation (user_inst, "test-without-runtime");
+  assert_remote_not_in_installation (user_inst, "test-runtime-only");
+
+  transaction = flatpak_transaction_new_for_installation (user_inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (transaction);
+
+  s = g_strconcat ("[Flatpak Ref]\n"
+                   "Title=Test App\n"
+                   "Name=org.test.Hello\n"
+                   "Branch=master\n"
+                   "Url=http://127.0.0.1:", httpd_port, "/test-without-runtime\n"
+                   "IsRuntime=False\n"
+                   "SuggestRemoteName=test-without-runtime-repo\n"
+                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test-runtime-only/test-runtime-only-repo.flatpakrepo\n",
+                   NULL);
+
+  data = g_bytes_new (s, strlen (s));
+  res = flatpak_transaction_add_install_flatpakref (transaction, data, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  g_signal_connect (transaction, "add-new-remote", G_CALLBACK (add_new_remote3), NULL);
+
+  res = flatpak_transaction_run (transaction, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  assert_remote_in_installation (user_inst, "test-without-runtime");
+  assert_remote_in_installation (user_inst, "test-runtime-only");
+
+  empty_installation (user_inst);
+  remove_remote_user ("test-without-runtime");
+  remove_remote_user ("test-runtime-only");
+  remove_remote_system ("test-without-runtime");
+  remove_remote_system ("test-runtime-only");
 }
 
 static gboolean
@@ -2729,7 +2878,7 @@ test_instance (void)
                              flatpak_get_default_arch ());
 
   update_test_app ();
-  update_repo ();
+  update_repo ("test");
 
   if (!check_bwrap_support ())
     {
@@ -3106,7 +3255,7 @@ test_install_flatpakref (void)
                    "Url=http://127.0.0.1:", httpd_port, "/test\n"
                    "IsRuntime=False\n"
                    "SuggestRemoteName=test-repo\n"
-                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test.flatpakrepo\n",
+                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test-repo.flatpakrepo\n",
                    NULL);
   data = g_bytes_new (s, strlen (s));
 
@@ -3295,7 +3444,7 @@ test_transaction_no_runtime (void)
                    "Url=http://127.0.0.1:", httpd_port, "/test-without-runtime\n"
                    "IsRuntime=False\n"
                    "SuggestRemoteName=my-little-repo\n"
-                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test.flatpakrepo\n",
+                   "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test-repo.flatpakrepo\n",
                    NULL);
 
   data = g_bytes_new (s, strlen (s));
@@ -3384,6 +3533,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/library/transaction", test_misc_transaction);
   g_test_add_func ("/library/transaction-install-uninstall", test_transaction_install_uninstall);
   g_test_add_func ("/library/transaction-install-flatpakref", test_transaction_install_flatpakref);
+  g_test_add_func ("/library/transaction-flatpakref-remote-creation", test_transaction_flatpakref_remote_creation);
   g_test_add_func ("/library/transaction-deps", test_transaction_deps);
   g_test_add_func ("/library/transaction-install-local", test_transaction_install_local);
   g_test_add_func ("/library/instance", test_instance);


### PR DESCRIPTION
These are cherry-picks of upstream patches from between 1.2.3 and 1.3.1 which are each either important or trivial and not risky. The only merge conflicts were trivial and are noted in the commit messages.

https://phabricator.endlessm.com/T26065