### PR TITLE
common: Do not convert G_IO_ERROR_CANCELLED errors to FLATPAK_ERROR d…

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -275,8 +275,18 @@ flatpak_remote_state_ensure_summary (FlatpakRemoteState *self,
                                      GError            **error)
 {
   if (self->summary == NULL)
-    return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Unable to load summary from remote %s: %s"), self->remote_name,
-                               self->summary_fetch_error != NULL ? self->summary_fetch_error->message : "unknown error");
+    {
+      if (self->summary_fetch_error != NULL &&
+          g_error_matches (self->summary_fetch_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        {
+          g_propagate_prefixed_error (error, g_error_copy (self->summary_fetch_error),
+                                      _("Unable to load summary from remote %s: "), self->remote_name);
+          return FALSE;
+        }
+
+      return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Unable to load summary from remote %s: %s"), self->remote_name,
+                                 self->summary_fetch_error != NULL ? self->summary_fetch_error->message : "unknown error");
+    }
 
   return TRUE;
 }
@@ -291,9 +301,30 @@ flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
 
       /* If the collection ID is NULL the metadata comes from the summary */
       if (self->metadata_fetch_error != NULL)
-        error_msg = g_strdup (self->metadata_fetch_error->message);
+        {
+          /* Fetch error can be IO_ERROR_CANCELLED in instances like quick searching of apps in software clients.
+           * Hence, avoid converting them to FLATPAK_ERROR from IO_ERROR domain so the clients can handle the
+           * cancellation appropriately. */
+          if (g_error_matches (self->metadata_fetch_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+            {
+              g_propagate_prefixed_error (error, g_error_copy (self->metadata_fetch_error),
+                                          _("Unable to load metadata from remote %s: "), self->remote_name);
+              return FALSE;
+            }
+
+          error_msg = g_strdup (self->metadata_fetch_error->message);
+        }
       else if (self->collection_id == NULL && self->summary_fetch_error != NULL)
-        error_msg = g_strdup_printf ("summary fetch error: %s", self->summary_fetch_error->message);
+        {
+          if (g_error_matches (self->summary_fetch_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+            {
+              g_propagate_prefixed_error (error, g_error_copy (self->summary_fetch_error),
+                                          _("Unable to load metadata from remote %s: "), self->remote_name);
+              return FALSE;
+            }
+
+          error_msg = g_strdup_printf ("summary fetch error: %s", self->summary_fetch_error->message);
+        }
 
       return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
                                  _("Unable to load metadata from remote %s: %s"),
@@ -4551,8 +4582,18 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
           g_autoptr(GError) my_error = NULL;
 
           if (!g_file_load_contents (extra_local_file, cancellable, &extra_local_contents, &extra_local_size, NULL, &my_error))
-            return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Failed to load local extra-data %s: %s"),
-                                       flatpak_file_get_path_cached (extra_local_file), my_error->message);
+            {
+              if  (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                {
+                  g_propagate_prefixed_error (error, g_steal_pointer (&my_error), _("Failed to load local extra-data %s"),
+                                              flatpak_file_get_path_cached (extra_local_file));
+                  return FALSE;
+                }
+
+              return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Failed to load local extra-data %s: %s"),
+                                         flatpak_file_get_path_cached (extra_local_file), my_error->message);
+	     }
+
           if (extra_local_size != download_size)
             return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Wrong size for extra-data %s"), flatpak_file_get_path_cached (extra_local_file));
 


### PR DESCRIPTION
…omain when fetching remote metadata.

While trying back and forth searching in gnome-software, G_IO_ERROR_CANCELLED
errors end up in the UI via the error-banner. It is quite a frustating UX.

GNOME Software already filters out G_IO_ERROR_CANCELLED errors from ending up
in the error-banner/UI; but still somehow many of these errors still were
ending up in the error-banner. This was due to the fact that these errors
were converted to FLATPAK_ERROR domain with code as FLATPAK_ERROR_INVALID_DATA
and hence were not filtered out by gnome-software.

Also, it's actually not right to have something like FLATPAK_ERROR_CANCELLED and
teach gnome-software to detect it. Hence, the approach here is to preserve the
error domain as G_IO_ERROR and error code as G_IO_ERROR_CANCELLED.

https://phabricator.endlessm.com/T23928