### PR TITLE
common: include ": " between prefix and existing message

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4585,7 +4585,7 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
             {
               if  (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
                 {
-                  g_propagate_prefixed_error (error, g_steal_pointer (&my_error), _("Failed to load local extra-data %s"),
+                  g_propagate_prefixed_error (error, g_steal_pointer (&my_error), _("Failed to load local extra-data %s: "),
                                               flatpak_file_get_path_cached (extra_local_file));
                   return FALSE;
                 }


### PR DESCRIPTION
As written, the error message would have no space or punctuation between
the extra-data path and the existing message. Other calls to
g_propagate_prefixed_error() added in
45a2eaf8a815f1647c4c36da29bd4e85d80e0f6d are fine.

https://phabricator.endlessm.com/T23928