### PR TITLE
Bump libmalcontent-0-dev min requirement to 0.4.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flatpak (1.3.3-1endless3) unstable; urgency=medium
+
+  * d/control: Bump libmalcontent-0-dev min requirement to 0.4.0
+
+ -- Andre Moreira Magalhaes <andre@endlessm.com>  Wed, 19 Jun 2019 15:23:19 -0300
+
 flatpak (1.3.3-1endless2) unstable; urgency=medium
 
   * d/control: Replace libeos-parental-controls-0-dev dep

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Build-Depends:
  libglib2.0-dev (>= 2.44),
  libgpgme-dev (>= 1.1.8),
  libjson-glib-dev,
- libmalcontent-0-dev (>= 0.3.0),
+ libmalcontent-0-dev (>= 0.4.0),
  libostree-dev (>= 2018.9),
  libpolkit-agent-1-dev,
  libpolkit-gobject-1-dev,


### PR DESCRIPTION
Depends on https://github.com/endlessm/flatpak/pull/165.

https://phabricator.endlessm.com/T27009
