### PR TITLE
polkit: Admins should always be allowed to install to system repo

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -8,7 +8,8 @@ polkit.addRule(function(action, subject) {
             return polkit.Result.YES;
     } else if (action.id == "org.freedesktop.Flatpak.app-install" &&
                subject.active == true && subject.local == true &&
-               action.lookup("parental-controls-repo-installation-allowed") === "1" &&
+               (subject.isInGroup("@privileged_group@") ||
+                action.lookup("parental-controls-repo-installation-allowed") === "1") &&
                action.lookup("parental-controls-is-appropriate") === "1") {
             return polkit.Result.YES;
     }


### PR DESCRIPTION
In 42563c5273a, we applied parental controls to administrators too,
but forgot to take into account the polkit rule change that is needed
to retain the default behaviour for app-installation for admins.
Admins historically, were able to install apps without a polkit
challenge (i.e. without requiring additional authorization for
system repo installation).

This commit brings back the default behavior for admin users, being
able to install to system repo without a polkit challenge.

During next rebase, this commit can be squashed with 42563c5273a.

https://phabricator.endlessm.com/T26968