### PR TITLE
Revert "tests: Temporarily disable failing tests due to recent GLib changes"

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3529,8 +3529,8 @@ main (int argc, char *argv[])
   g_test_add_func ("/library/list-updates", test_list_updates);
   g_test_add_func ("/library/transaction", test_misc_transaction);
   g_test_add_func ("/library/transaction-install-uninstall", test_transaction_install_uninstall);
-  //g_test_add_func ("/library/transaction-install-flatpakref", test_transaction_install_flatpakref);
-  //g_test_add_func ("/library/transaction-flatpakref-remote-creation", test_transaction_flatpakref_remote_creation);
+  g_test_add_func ("/library/transaction-install-flatpakref", test_transaction_install_flatpakref);
+  g_test_add_func ("/library/transaction-flatpakref-remote-creation", test_transaction_flatpakref_remote_creation);
   g_test_add_func ("/library/transaction-deps", test_transaction_deps);
   g_test_add_func ("/library/transaction-install-local", test_transaction_install_local);
   g_test_add_func ("/library/instance", test_instance);
@@ -3542,7 +3542,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/library/list-installed-related-refs", test_list_installed_related_refs);
   g_test_add_func ("/library/no-deploy", test_no_deploy);
   g_test_add_func ("/library/bad-remote-name", test_bad_remote_name);
-  //g_test_add_func ("/library/transaction-no-runtime", test_transaction_no_runtime);
+  g_test_add_func ("/library/transaction-no-runtime", test_transaction_no_runtime);
   g_test_add_func ("/library/installation-no-interaction", test_installation_no_interaction);
   g_test_add_func ("/library/installation-unused-refs", test_installation_unused_refs);
 


### PR DESCRIPTION
The changes to dconf to fix the test failures are now merged upstream[1]. Lets re-enable the tests.

This change depends on the new dconf package. Current OBS MR at https://obs-master.endlessm-sf.com/request/show/20486.

Once this lands we need to backport both this change and push the updated dconf package to 3.6.

https://phabricator.endlessm.com/T27345

[1] https://gitlab.gnome.org/GNOME/dconf/merge_requests/51