### PR TITLE
common/dir: Skip parental controls checks when running from the eos-image-builder

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7653,6 +7653,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
 #ifdef HAVE_LIBMALCONTENT
   g_autoptr(GError) local_error = NULL;
   const char *on_session = g_getenv ("FLATPAK_SYSTEM_HELPER_ON_SESSION");
+  const char *skip_parental_controls_no_system_bus = g_getenv ("FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS");
   g_autoptr(GDBusConnection) dbus_connection = NULL;
   g_autoptr(MctManager) manager = NULL;
   g_autoptr(MctAppFilter) app_filter = NULL;
@@ -7687,6 +7688,16 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   dbus_connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, cancellable, &local_error);
   if (dbus_connection == NULL)
     {
+      if (skip_parental_controls_no_system_bus != NULL)
+        {
+          /* FIXME: The image builder doesn't run the system bus and thus there
+           * is no way to check parental controls, so lets skip it.
+           * https://phabricator.endlessm.com/T27896 */
+          g_debug ("Skipping parental controls check for %s as requested since "
+                   "the system bus is unavailable in the environment", ref);
+          return TRUE;
+        }
+
       g_propagate_error (error, g_steal_pointer (&local_error));
       return FALSE;
     }


### PR DESCRIPTION

The image builder doesn't have the system bus available which is required to
run the parental controls checks, so lets skip it if the
FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS env variable is set (set by the builder)
and system bus is not available.

https://phabricator.endlessm.com/T27896