### PR TITLE
installation: don't dereference possibly-NULL array

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1147,7 +1147,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
         g_debug ("No remotes found which provide these refs: [%s]", refs_str->str);
     }
 
-  for (i = 0; i < installed->len && results[0] != NULL; i++)
+  for (i = 0; i < installed->len && results != NULL && results[0] != NULL; i++)
     {
       FlatpakInstalledRef *installed_ref = g_ptr_array_index (installed, i);
       const char *remote_name = flatpak_installed_ref_get_origin (installed_ref);


### PR DESCRIPTION
If the installation contains 1 or more installed refs, but none of those
refs have a remote with a collection ID, then 'results' will be NULL but
'installed' will be non-NULL. Since
c29e686246086fa24a9cf9ba291d0e2f43420e06, 'results[0]' is used in this
situation – a NULL pointer dereference. There is an existing 'results !=
NULL' check inside the body of this loop, but this is too late.

Check whether 'results' is NULL before dereferencing it.

Submitted upstream as https://github.com/flatpak/flatpak/pull/3135.

https://phabricator.endlessm.com/T27912
