### PR TITLE
app: Allow locales to be stored in the extra-languages key

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -951,7 +951,9 @@ gboolean           flatpak_dir_resolve_p2p_refs (FlatpakDir         *self,
                                                  GError            **error);
 
 
+char ** flatpak_dir_get_default_locales (FlatpakDir *self);
 char ** flatpak_dir_get_default_locale_languages (FlatpakDir *self);
+char ** flatpak_dir_get_locales (FlatpakDir *self);
 char ** flatpak_dir_get_locale_languages (FlatpakDir *self);
 char ** flatpak_dir_get_locale_subpaths (FlatpakDir *self);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14481,20 +14481,13 @@ flatpak_dir_get_config_strv (FlatpakDir *self, char *key)
   return NULL;
 }
 
-char **
-flatpak_dir_get_default_locale_languages (FlatpakDir *self)
+static void
+get_system_locales (FlatpakDir *self, GPtrArray *langs)
 {
-  g_autoptr(GPtrArray) langs = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GDBusProxy) localed_proxy = NULL;
   g_autoptr(GDBusProxy) accounts_proxy = NULL;
-  g_auto(GStrv) extra_languages = NULL;
 
-  extra_languages = flatpak_dir_get_config_strv (self, "xa.extra-languages");
-
-  if (flatpak_dir_is_user (self))
-    return sort_strv (flatpak_strv_merge (extra_languages, flatpak_get_current_locale_langs ()));
-
-  /* Then get the system default locales */
+  /* Get the system default locales */
   localed_proxy = get_localed_dbus_proxy ();
   if (localed_proxy != NULL)
     get_locale_langs_from_localed_dbus (localed_proxy, langs);
@@ -14504,11 +14497,66 @@ flatpak_dir_get_default_locale_languages (FlatpakDir *self)
   accounts_proxy = get_accounts_dbus_proxy ();
   if (accounts_proxy != NULL)
     get_locale_langs_from_accounts_dbus (accounts_proxy, langs);
-
   g_ptr_array_add (langs, NULL);
+}
+
+char **
+flatpak_dir_get_default_locales (FlatpakDir *self)
+{
+  g_autoptr(GPtrArray) langs = g_ptr_array_new_with_free_func (g_free);
+  g_auto(GStrv) extra_languages = NULL;
+
+  extra_languages = flatpak_dir_get_config_strv (self, "xa.extra-languages");
+
+  if (flatpak_dir_is_user (self))
+    return sort_strv (flatpak_strv_merge (extra_languages, flatpak_get_current_locale_langs ()));
+
+  /* Then get the system default locales */
+  get_system_locales (self, langs);
 
   return sort_strv (flatpak_strv_merge (extra_languages, (char **) langs->pdata));
 }
+
+char **
+flatpak_dir_get_default_locale_languages (FlatpakDir *self)
+{
+  g_autoptr(GPtrArray) langs = g_ptr_array_new_with_free_func (g_free);
+  g_auto(GStrv) extra_languages = NULL;
+  int i;
+
+  extra_languages = flatpak_dir_get_config_strv (self, "xa.extra-languages");
+  for (i = 0; extra_languages != NULL && extra_languages[i] != NULL; i++)
+    {
+       g_auto(GStrv) locales = g_strsplit (extra_languages[i], "_", -1);
+       g_free (extra_languages[i]);
+       extra_languages[i] = g_strdup (locales[0]);
+    }
+
+  if (flatpak_dir_is_user (self))
+    return sort_strv (flatpak_strv_merge (extra_languages, flatpak_get_current_locale_langs ()));
+
+  /* Then get the system default locales */
+  get_system_locales (self, langs);
+
+  return sort_strv (flatpak_strv_merge (extra_languages, (char **) langs->pdata));
+}
+
+char **
+flatpak_dir_get_locales (FlatpakDir *self)
+{
+  char **langs = NULL;
+
+  /* Fetch the list of languages specified by xa.languages - if this key is empty,
+   * this would mean that all languages are accepted. You can read the man for the
+   * flatpak-config section for more info.
+   */
+  langs = flatpak_dir_get_config_strv (self, "xa.languages");
+  if (langs)
+    return sort_strv (langs);
+
+  return flatpak_dir_get_default_locales (self);
+}
+
 
 char **
 flatpak_dir_get_locale_languages (FlatpakDir *self)

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1677,6 +1677,32 @@ flatpak_installation_get_default_languages (FlatpakInstallation  *self,
 }
 
 /**
+ * flatpak_installation_get_default_locales:
+ * @self: a #FlatpakInstallation
+ * @error: return location for a #GError
+ *
+ * Like flatpak_installation_get_default_languages() but includes region 
+ * information (e.g. en_US rather than en) which may be included in the 
+ * xa.extra-languages configuration.
+ *
+ * Returns: (array zero-terminated=1) (element-type utf8) (transfer full):
+ *   A possibly empty array of language and locale strings, or %NULL on error.
+ * Since: 1.5.1
+ */
+char **
+flatpak_installation_get_default_locales (FlatpakInstallation  *self,
+                                          GError              **error)
+{
+  g_autoptr(FlatpakDir) dir = NULL;
+
+  dir = flatpak_installation_get_dir (self, error);
+  if (dir == NULL)
+    return NULL;
+
+  return flatpak_dir_get_locales (dir);
+}
+
+/**
  * flatpak_installation_get_min_free_space_bytes:
  * @self: a #FlatpakInstallation
  * @out_bytes: (out): Location to store the result

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -298,6 +298,8 @@ FLATPAK_EXTERN char *                flatpak_installation_get_config (FlatpakIns
                                                                       GError             **error);
 FLATPAK_EXTERN char **               flatpak_installation_get_default_languages (FlatpakInstallation  *self,
                                                                                  GError              **error);
+FLATPAK_EXTERN char **               flatpak_installation_get_default_locales (FlatpakInstallation  *self,
+                                                                               GError              **error);
 FLATPAK_EXTERN char *              flatpak_installation_load_app_overrides (FlatpakInstallation *self,
                                                                             const char          *app_id,
                                                                             GCancellable        *cancellable,

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -70,7 +70,8 @@
                 <listitem><para>
                    This key is used when languages is not set, and it defines extra locale
                    extensions on top of the system configured languages. The value is a
-                   semicolon-separated list of two-letter language codes.
+                   semicolon-separated list of two-letter language codes or locale identifiers
+                   (eg. en;en_DK;az_Latn_AZ).
                 </para></listitem>
             </varlistentry>
         </variablelist>


### PR DESCRIPTION
In order to configure gnome-software to show specific apps in one region
without showing to all language speakers, we allow the storage of full
locales on the extra-languages key. However, these locales are ignored when
calling flatpak_installation_get_default_languages, so locales will be reduced
to their language identifier (eg. en_IN locale will be returned as 'en', and
az_Latn_AZ will be returned as 'az'). In order to get the full locales, we can
call flatpak_installation_get_default_locales instead, which can return languages
and locales.

(cherry picked from commit 65912f27fe1f2300819ece27fbeb4e2095bbdfd3)