### PR TITLE
utils: Allow chaining OstreeAsyncProgress when pushing GMainContext

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4822,8 +4822,8 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                               GError                              **error)
 {
   g_autoptr(GVariant) extra_data_sources = NULL;
-  int i;
-  gsize n_extra_data;
+  guint64 i;
+  guint64 n_extra_data;
   guint64 total_download_size;
 
   /* If @results is set, @rev must be. */
@@ -4879,8 +4879,8 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   if (progress)
     {
       ostree_async_progress_set (progress,
-                                 "outstanding-extra-data", "u", n_extra_data,
-                                 "total-extra-data", "u", n_extra_data,
+                                 "outstanding-extra-data", "t", n_extra_data,
+                                 "total-extra-data", "t", n_extra_data,
                                  "total-extra-data-bytes", "t", total_download_size,
                                  "transferred-extra-data-bytes", "t", (guint64) 0,
                                  "downloading-extra-data", "u", 0,
@@ -5031,7 +5031,7 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
 
       extra_data_progress.previous_dl += download_size;
       if (progress)
-        ostree_async_progress_set_uint (progress, "outstanding-extra-data", n_extra_data - i - 1);
+        ostree_async_progress_set_uint64 (progress, "outstanding-extra-data", n_extra_data - i - 1);
 
       sha256 = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, bytes);
       if (strcmp (sha256, extra_data_sha256) != 0)
@@ -5122,8 +5122,8 @@ oci_pull_init_progress (OstreeAsyncProgress *progress)
                              "start-time", "t", start_time,
                              "outstanding-metadata-fetches", "u", 0,
                              "metadata-fetched", "u", 0,
-                             "outstanding-extra-data", "u", 0,
-                             "total-extra-data", "u", 0,
+                             "outstanding-extra-data", "t", (guint64) 0,
+                             "total-extra-data", "t", (guint64) 0,
                              "total-extra-data-bytes", "t", (guint64) 0,
                              "transferred-extra-data-bytes", "t", (guint64) 0,
                              "downloading-extra-data", "u", 0,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4617,6 +4617,7 @@ repo_pull (OstreeRepo                           *self,
       OstreeCollectionRef *collection_refs_to_fetch[2];
       guint32 update_freq = 0;
       g_autoptr(GMainContextPopDefault) context = NULL;
+      g_autoptr(FlatpakAsyncProgressChained) chained_progress = NULL;
 
       pulled_using_p2p = TRUE;
 
@@ -4624,6 +4625,7 @@ repo_pull (OstreeRepo                           *self,
       collection_ref.ref_name = (char *) ref_to_fetch;
 
       context = flatpak_main_context_new_default ();
+      chained_progress = flatpak_progress_chain (progress);
 
       if (results_to_fetch == NULL)
         {
@@ -4660,7 +4662,8 @@ repo_pull (OstreeRepo                           *self,
 
           ostree_repo_find_remotes_async (self, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,
-                                          NULL /* default finders */, progress, cancellable,
+                                          NULL /* default finders */,
+                                          chained_progress, cancellable,
                                           async_result_cb, &find_result);
 
           while (find_result == NULL)
@@ -4695,7 +4698,7 @@ repo_pull (OstreeRepo                           *self,
           pull_options = g_variant_ref_sink (g_variant_builder_end (&pull_builder));
 
           ostree_repo_pull_from_remotes_async (self, results_to_fetch,
-                                               pull_options, progress,
+                                               pull_options, chained_progress,
                                                cancellable, async_result_cb,
                                                &pull_result);
 
@@ -5414,6 +5417,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
           gboolean force_disable_deltas = (flatpak_flags & FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS) != 0;
           guint update_freq = 0;
           g_autoptr(GMainContextPopDefault) context = NULL;
+          g_autoptr(FlatpakAsyncProgressChained) chained_progress = NULL;
 
           /* FIXME: It would be nice to break out a helper function from
            * flatpak_dir_do_resolve_p2p_refs() that would resolve refs to
@@ -5444,10 +5448,12 @@ flatpak_dir_pull (FlatpakDir                           *self,
           find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
           context = flatpak_main_context_new_default ();
+          chained_progress = flatpak_progress_chain (progress);
 
           ostree_repo_find_remotes_async (repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,
-                                          NULL /* default finders */, progress, cancellable,
+                                          NULL /* default finders */,
+                                          chained_progress, cancellable,
                                           async_result_cb, &find_result);
 
           while (find_result == NULL)
@@ -5477,7 +5483,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
               if (!repo_pull (repo, state->remote_name,
                               NULL, ref, NULL, results,
                               flatpak_flags, metadata_pull_flags,
-                              progress, cancellable, error))
+                              chained_progress, cancellable, error))
                 {
                   g_prefix_error (error, _("While pulling %s from remote %s: "), ref, state->remote_name);
                   goto out;

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -812,6 +812,18 @@ typedef void (*FlatpakProgressCallback)(const char *status,
 OstreeAsyncProgress *flatpak_progress_new (FlatpakProgressCallback progress,
                                            gpointer                progress_data);
 
+OstreeAsyncProgress *flatpak_progress_chain (OstreeAsyncProgress *progress);
+
+static inline void
+flatpak_progress_unchain (OstreeAsyncProgress *chained_progress)
+{
+  if (chained_progress != NULL)
+    ostree_async_progress_finish (chained_progress);
+}
+
+typedef OstreeAsyncProgress FlatpakAsyncProgressChained;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakAsyncProgressChained, flatpak_progress_unchain);
+
 void flatpak_log_dir_access (FlatpakDir *dir);
 
 gboolean flatpak_check_required_version (const char *ref,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6196,7 +6196,7 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
   guint64 bytes_transferred;
   guint64 fetched_delta_part_size;
   guint64 total_delta_part_size;
-  guint outstanding_extra_data;
+  guint64 outstanding_extra_data;
   guint64 total_extra_data_bytes;
   guint64 transferred_extra_data_bytes;
   guint64 total = 0;
@@ -6280,7 +6280,7 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
                              "requested", "u", &requested,
                              "start-time", "t", &start_time,
                              "status", "s", &status,
-                             "outstanding-extra-data", "u", &outstanding_extra_data,
+                             "outstanding-extra-data", "t", &outstanding_extra_data,
                              "total-extra-data-bytes", "t", &total_extra_data_bytes,
                              "transferred-extra-data-bytes", "t", &transferred_extra_data_bytes,
                              "downloading-extra-data", "u", &downloading_extra_data,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6217,11 +6217,13 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
   guint64 total_transferred;
   g_autofree gchar *formatted_bytes_total_transferred = NULL;
   g_autoptr(GVariant) outstanding_fetchesv = NULL;
+  g_autoptr(GVariant) outstanding_extra_datav = NULL;
 
   /* We get some extra calls before we've really started due to the initialization of the
      extra data, so ignore those */
   outstanding_fetchesv = ostree_async_progress_get_variant (progress, "outstanding-fetches");
-  if (outstanding_fetchesv == NULL)
+  outstanding_extra_datav = ostree_async_progress_get_variant (progress, "outstanding-extra-data");
+  if (outstanding_fetchesv == NULL || outstanding_extra_datav == NULL)
     return;
 
   buf = g_string_new ("");

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6411,10 +6411,116 @@ flatpak_progress_new (FlatpakProgressCallback progress,
                                            progress_data);
 
   g_object_set_data (G_OBJECT (ostree_progress), "callback", progress);
+  g_object_set_data (G_OBJECT (ostree_progress), "callback_data", progress_data);
   g_object_set_data (G_OBJECT (ostree_progress), "last_progress", GUINT_TO_POINTER (0));
   g_object_set_data (G_OBJECT (ostree_progress), "last_total", GUINT_TO_POINTER (0));
+  g_object_set_data (G_OBJECT (ostree_progress), "chained_from", NULL);
 
   return ostree_progress;
+}
+
+static void
+handle_chained_progress (OstreeAsyncProgress *chained_progress,
+                         gpointer             user_data)
+{
+  OstreeAsyncProgress *original_progress = (OstreeAsyncProgress *) user_data;
+
+  /* Sync the chained progress's state back to the original instance, to take
+   * into account any updates received while a different GMainContext was
+   * active */
+  ostree_async_progress_copy_state (chained_progress, original_progress);
+
+  OstreeAsyncProgress *chained_from =
+    OSTREE_ASYNC_PROGRESS (g_object_get_data (G_OBJECT (original_progress), "chained_from"));
+  FlatpakProgressCallback chained_callback =
+    g_object_get_data (G_OBJECT (original_progress), "callback");
+
+  if (chained_from != NULL)
+    {
+      /* It's possible we chained to an already-chained progress object. */
+      handle_chained_progress (original_progress, chained_from);
+    }
+  else if (chained_callback != NULL)
+    {
+      /* The normal case; we chained to a progress object created by
+       * flatpak_progress_new(). */
+      gpointer original_data = g_object_get_data (G_OBJECT (original_progress), "callback_data");
+      progress_cb (original_progress, original_data);
+    }
+  else
+    {
+      /* Do nothing. It's possible we chained to a progress object without the
+       * GObject data, that was not created by flatpak_progress_new().
+       * Unfortunately it doesn't seem possible to call the callback in this
+       * case. */
+    }
+}
+
+/*
+ * This is necessary when pushing a temporary GMainContext to be the thread
+ * default with flatpak_main_context_new_default() in order to call an async
+ * operation as if it were sync, if you have an OstreeAsyncProgress object that
+ * would otherwise be forwarded into the async operation.
+ *
+ * This is because the original OstreeAsyncProgress object won't receive any
+ * signals while the temporary GMainContext is active, since the GMainContext it
+ * was created with won't be iterated.
+ *
+ * Note that this should only be done when the two GMainContexts are in the same
+ * thread. If they are in different threads, then the progress's update callback
+ * will be called from the wrong thread.
+ *
+ * tl;dr instead of this:
+ *
+ *     my_operation (OstreeAsyncProgress *progress)
+ *     {
+ *       g_autoptr(GMainContextPopDefault) context = NULL;
+ *       context = flatpak_main_context_new_default ();
+ *       ostree_some_async_op (progress, some_callback_setting_some_flag, data);
+ *       while (wait_for_flag)
+ *         g_main_context_iteration (context, TRUE);
+ *     }
+ *
+ * do this:
+ *
+ *     my_operation (OstreeAsyncProgress *progress)
+ *     {
+ *       g_autoptr(GMainContextPopDefault) context = NULL;
+ *       g_autoptr(FlatpakAsyncProgressChained) chained_progress = NULL;
+ *       context = flatpak_main_context_new_default ();
+ *       chained_progress = flatpak_progress_chain (progress);
+ *       ostree_some_async_op (chained_progress,
+ *                             some_callback_setting_some_flag, data);
+ *       while (wait_for_flag)
+ *         g_main_context_iteration (context, TRUE);
+ *     }
+ *
+ * This is a no-op, preserving the current behaviour where progress events are
+ * not fired, if the libostree version isn't new enough.
+ */
+OstreeAsyncProgress *
+flatpak_progress_chain (OstreeAsyncProgress *progress)
+{
+  if (progress == NULL)
+    return NULL;
+
+  OstreeAsyncProgress *chained_progress = ostree_async_progress_new ();
+
+  /* Copy the OstreeAsyncProgress's state to the chained instance */
+  ostree_async_progress_copy_state (progress, chained_progress);
+
+  g_signal_connect (chained_progress, "changed",
+                    G_CALLBACK (handle_chained_progress), progress);
+
+  /* Now initialize the expected FlatpakProgress state on the chained instance */
+
+  g_object_set_data (G_OBJECT (chained_progress), "callback", NULL);
+  g_object_set_data (G_OBJECT (chained_progress), "callback_data", NULL);
+  g_object_set_data (G_OBJECT (chained_progress), "last_progress", GUINT_TO_POINTER (0));
+  g_object_set_data (G_OBJECT (chained_progress), "last_total", GUINT_TO_POINTER (0));
+  g_object_set_data (G_OBJECT (chained_progress), "chained_from", progress);
+
+  return chained_progress;
 }
 
 void


### PR DESCRIPTION
It's a common idiom in this codebase to push a temporary GMainContext as
the thread default context in order to run an async operation as if it
were sync. If we are not expecting progress callbacks this isn't a
problem, but it becomes a problem if we pass in an OstreeAsyncProgress
object that was created under a different GMainContext. The reason for
this is that OstreeAsyncProgress creates an idle source and attaches it
to the thread default context, so if we are iterating a temporary
context then the OstreeAsyncProgress's context never gets iterated, and
so no progress signals are fired.

To fix this, we introduce flatpak_progress_chain() and a RAII helper
OstreeAsyncProgressChained which creates a new OstreeAsyncProgress under
the temporary GMainContext, but forwards all its state and updates to
the previous OstreeAsyncProgress's callbacks.

This is documented in a comment in the code as well.

All known instances of this problem in the existing code are fixed in
this commit.

This problem was solved conceptually by Philip Withnall, I only wrote
the code.

https://phabricator.endlessm.com/T26965