### PR TITLE
flatpak-parental-controls: Properly initialize appdata_value when checking oars rating

### DIFF
--- a/common/flatpak-parental-controls.c
+++ b/common/flatpak-parental-controls.c
@@ -113,7 +113,7 @@ flatpak_oars_check_rating (GHashTable   *content_rating,
       MctAppFilterOarsValue rating_value;
       MctAppFilterOarsValue filter_value = mct_app_filter_get_oars_value (filter,
                                                                           oars_sections[i]);
-      const gchar *appdata_value;
+      const gchar *appdata_value = NULL;
 
       if (content_rating != NULL)
         appdata_value = g_hash_table_lookup (content_rating, oars_sections[i]);


### PR DESCRIPTION
Fix the following warning:
common/flatpak-parental-controls.c: In function ‘flatpak_oars_check_rating’:
common/flatpak-parental-controls.c:121:10: warning: ‘appdata_value’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       if (appdata_value != NULL)
          ^

Upstream PR: https://github.com/flatpak/flatpak/pull/3210