### PR TITLE
common/dir: set MIRROR flag consistently when pulling commits

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4814,6 +4814,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                               const char                           *rev,
                               const OstreeRepoFinderResult * const *results,
                               FlatpakPullFlags                      flatpak_flags,
+                              OstreeRepoPullFlags                   flags,
                               OstreeAsyncProgress                  *progress,
                               GCancellable                         *cancellable,
                               GError                              **error)
@@ -4829,6 +4830,8 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
   if (extra_data_sources == NULL)
     {
+      flags |= OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
+
       /* Pull the commits (and only the commits) to check for extra data
        * again. Here we don't pass the progress because we don't want any
        * reports coming out of it. */
@@ -4838,7 +4841,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                       rev,
                       results,
                       flatpak_flags,
-                      OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY,
+                      flags,
                       NULL,
                       cancellable,
                       error))
@@ -5394,6 +5397,11 @@ flatpak_dir_pull (FlatpakDir                           *self,
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     goto out;
 
+#if OSTREE_CHECK_VERSION (2019, 2)
+  if (state->collection_id)
+    flags |= OSTREE_REPO_PULL_FLAGS_MIRROR;
+#endif
+
   /* We get the rev ahead of time so that we know it for looking up e.g. extra-data
      and to make sure we're atomically using a single rev if we happen to do multiple
      pulls (e.g. with subpaths) */
@@ -5472,8 +5480,6 @@ flatpak_dir_pull (FlatpakDir                           *self,
           if (results[0] != NULL)
             {
               OstreeRepoPullFlags metadata_pull_flags = flags | OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
-              /*TODO: Use OSTREE_REPO_PULL_FLAGS_MIRROR for all collection-ref pulls */
-              metadata_pull_flags |= OSTREE_REPO_PULL_FLAGS_MIRROR;
               if (!repo_pull (repo, state->remote_name,
                               NULL, ref, NULL, results,
                               flatpak_flags, metadata_pull_flags,
@@ -5537,6 +5543,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
   if (!flatpak_dir_setup_extra_data (self, repo, state->remote_name,
                                      ref, rev, results,
                                      flatpak_flags,
+                                     flags,
                                      progress,
                                      cancellable,
                                      error))

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4900,8 +4900,6 @@ reset_async_progress_extra_data (OstreeAsyncProgress *progress)
 static gboolean
 flatpak_dir_pull_extra_data (FlatpakDir          *self,
                              OstreeRepo          *repo,
-                             const char          *repository,
-                             const char          *ref,
                              const char          *rev,
                              FlatpakPullFlags     flatpak_flags,
                              OstreeAsyncProgress *progress,
@@ -5562,9 +5560,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
       goto out;
     }
 
-  if (!flatpak_dir_pull_extra_data (self, repo,
-                                    state->remote_name,
-                                    ref, rev,
+  if (!flatpak_dir_pull_extra_data (self, repo, rev,
                                     flatpak_flags,
                                     progress,
                                     cancellable,


### PR DESCRIPTION
The pull to fetch our commit metadata uses the MIRROR flag since
8cea78d, however this is not applied consistently in the other pulls
done in flatpak_dir_setup_extra_data and flatpak_dir_pull. The result
is that two refs are added to the OSTree transaction - one remote ref
and one collection ref, but only one is found in future by
flatpak_repo_resolve_rev so the other is shadowed and ultimately
leaked. Apply the same conditions and pass the MIRROR flag consistently
so that only one ref is created.

https://phabricator.endlessm.com/T28344