### PR TITLE
T28819: enable search based on the provider bus name, not the app ID

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6541,7 +6541,12 @@ export_ini_file (int                 parent_fd,
     return FALSE;
 
   if (ini_type == INI_FILE_TYPE_SEARCH_PROVIDER)
-    g_key_file_set_boolean (keyfile, "Shell Search Provider", "DefaultDisabled", TRUE);
+    {
+      g_autofree gchar *bus_name = g_key_file_get_string (keyfile, "Shell Search Provider", "BusName", NULL);
+
+      if (bus_name == NULL || !g_str_has_prefix (bus_name, "com.endlessm."))
+        g_key_file_set_boolean (keyfile, "Shell Search Provider", "DefaultDisabled", TRUE);
+    }
 
   new_data = g_key_file_to_data (keyfile, &new_data_len, error);
   if (new_data == NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7036,9 +7036,6 @@ rewrite_export_dir (const char         *app,
           if (strcmp (source_name, "search-providers") == 0 &&
               g_str_has_suffix (dent->d_name, ".ini"))
             {
-              if (g_str_has_prefix (app, "com.endlessm."))
-                continue;
-
               if (!export_ini_file (source_iter.fd, dent->d_name, INI_FILE_TYPE_SEARCH_PROVIDER,
                                     &stbuf, &new_name, cancellable, error))
                 goto out;

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -76,6 +76,15 @@ MimeType=x-test/Hello;
 X-Flatpak-RenamedFrom=hello-again.desktop;
 EOF
 
+mkdir -p ${DIR}/files/share/gnome-shell/search-providers
+cat > ${DIR}/files/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini <<EOF
+[Shell Search Provider]
+DesktopId=org.test.Hello.desktop
+BusName=org.test.Hello.SearchProvider
+ObjectPath=/org/test/Hello/SearchProvider
+Version=2
+EOF
+
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/dont-export.png

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -84,6 +84,13 @@ BusName=org.test.Hello.SearchProvider
 ObjectPath=/org/test/Hello/SearchProvider
 Version=2
 EOF
+cat > ${DIR}/files/share/gnome-shell/search-providers/org.test.Hello.Ekn.search-provider.ini <<EOF
+[Shell Search Provider]
+DesktopId=org.test.Hello.desktop
+BusName=com.endlessm.EknServices3.SearchProviderV3
+ObjectPath=/org/test/Hello/SearchProvider
+Version=2
+EOF
 
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -48,6 +48,8 @@ assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini
 assert_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini "^DefaultDisabled=true$"
+assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.Ekn.search-provider.ini
+assert_not_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.Ekn.search-provider.ini "^DefaultDisabled=true$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
 assert_not_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/dont-export.png
 assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -46,6 +46,8 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
 assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini
+assert_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini "^DefaultDisabled=true$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
 assert_not_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/dont-export.png
 assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png


### PR DESCRIPTION
Currently we filter by app IDs to determine which search providers to enable, which means Hack and Endless Network knowledge apps are not searchable by default. Revert this patch, and instead check the BusName of search provider .ini files which are exported, and do not disable those where the search provider is from com.endlessm, so that all knowledge apps are searchable by default.

https://phabricator.endlessm.com/T28819