### PR TITLE
allow fetching flatpak extensions with extra_data

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5251,6 +5251,9 @@ apply_extra_data (FlatpakDir          *self,
   runtime = g_key_file_get_string (metakey, group,
                                    FLATPAK_METADATA_KEY_RUNTIME, error);
   if (runtime == NULL)
+    runtime = g_key_file_get_string (metakey, FLATPAK_METADATA_GROUP_EXTENSION_OF,
+                                     FLATPAK_METADATA_KEY_RUNTIME, NULL);
+  if (runtime == NULL)
     return FALSE;
 
   runtime_ref = g_build_filename ("runtime", runtime, NULL);


### PR DESCRIPTION
The upstream commit flatpak/flatpak@2fdad837 from the upstream 1.0.x branch adds support for extensions which use extra_data. Pick this patch into eos3.3 so that the Flatpak fetch process in eos-updater can successfully fetch the OpenH.264 decoder, which is now an auto-installed extension of the freedesktop.org 19.08 runtime and relies on extra_data, one of my worse ideas this year.

Note that I have considered, and excluded, these other related patches from Flatpak 1.0.9:
- flatpak/flatpak@18baeac0: Flatpak 0.10.x predates FlatpakTransaction being exposed as public API so this patch doesn't apply - in practice, only the command line tool uses the original transaction implementation. In EOS 3.3, both eos-updater and gnome-software use the older FlatpakInstallation API, and in the specific OpenH264 case we care about, the required runtime (19.08) should already be fetched as a related ref.
- flatpak/flatpak@0ae3137c, flatpak/flatpak@b89a422a: Similarly, the required-flatpak key is only checked when using the original transaction API through the CLI, and is bypassed in the rest of the OS in 3.3. There is no benefit making this check work for our Flatpak 0.10.x, because the extra_data extensions feature doesn't exist in 0.10 - if we made the check work, it would never be satisfied because the lowest upstream version that supports it is 1.0.9. The fact the check is ordinarily bypassed works in our favour, in this case.

https://phabricator.endlessm.com/T28626