### PR TITLE
installation: Cache remote states while querying installed refs

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1019,6 +1019,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
   g_autoptr(GPtrArray) installed = NULL; /* (element-type FlatpakInstalledRef) */
   g_autoptr(GPtrArray) remotes = NULL; /* (element-type FlatpakRemote) */
   g_autoptr(GHashTable) remote_commits = NULL; /* (element-type utf8 utf8) */
+  g_autoptr(GHashTable) remote_states = NULL; /* (element-type utf8 FlatpakRemoteState) */
   int i, j;
   g_autoptr(FlatpakDir) dir = NULL;
   g_auto(OstreeRepoFinderResultv) results = NULL;
@@ -1082,9 +1083,11 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
+  remote_states = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) flatpak_remote_state_unref);
+
   for (i = 0; i < installed->len; i++)
     {
-      g_autoptr(FlatpakRemoteState) state = NULL;
+      FlatpakRemoteState *state;
       FlatpakInstalledRef *installed_ref = g_ptr_array_index (installed, i);
       const char *remote_name = flatpak_installed_ref_get_origin (installed_ref);
       g_autofree char *full_ref = flatpak_ref_format_ref (FLATPAK_REF (installed_ref));
@@ -1112,9 +1115,16 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
        * This makes sure that the ref (maybe an app or runtime) remains in usable
        * state and fixes itself through an update.
        */
-      state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+      state = g_hash_table_lookup (remote_states, remote_name);
       if (state == NULL)
-        continue;
+        {
+
+          state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+          if (state == NULL)
+            continue;
+
+          g_hash_table_insert (remote_states, g_strdup (remote_name), state);
+        }
 
       if (flatpak_dir_check_installed_ref_missing_related_ref (dir, state, full_ref, cancellable))
         {

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1094,6 +1094,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
       g_autofree char *key = g_strdup_printf ("%s:%s", remote_name, full_ref);
       const char *remote_commit = g_hash_table_lookup (remote_commits, key);
       const char *local_commit = flatpak_installed_ref_get_latest_commit (installed_ref);
+      g_autoptr(GError) local_error = NULL;
 
       if (flatpak_dir_ref_is_masked (dir, full_ref))
         continue;
@@ -1119,9 +1120,13 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
       if (state == NULL)
         {
 
-          state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+          state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, &local_error);
           if (state == NULL)
-            continue;
+            {
+              g_debug ("Update: Failed to get remote state for %s: %s",
+                       remote_name, local_error->message);
+              continue;
+            }
 
           g_hash_table_insert (remote_states, g_strdup (remote_name), state);
         }


### PR DESCRIPTION
Cache remote state so that each remote is only queried once
for getting its state.

Follow up from https://github.com/flatpak/flatpak/pull/3204#discussion_r349642324

This can be dropped in next rebase cycle.
Backported from https://github.com/flatpak/flatpak/pull/3259