### PR TITLE
build-commit-from: Fix generation of download-size

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3248,6 +3248,11 @@ flatpak_repo_collect_sizes (OstreeRepo   *repo,
                             GCancellable *cancellable,
                             GError      **error)
 {
+  /* Initialize the sums */
+  if (installed_size)
+    *installed_size = 0;
+  if (download_size)
+    *download_size = 0;
   return _flatpak_repo_collect_sizes (repo, root, NULL, installed_size, download_size, cancellable, error);
 }
 


### PR DESCRIPTION
In flatpak-builtins-build-commit-from.c we call flatpak_repo_collect_sizes()
without initializing the passed in download size to zero, which mean
we sum with sizes with some random value as the start.

This is fixed by having flatpak_repo_collect_sizes() always initialize
the counters to 0 at the start.

Fixes https://github.com/flatpak/flatpak/issues/3362

(cherry picked from commit 3c6c51f46b753934cff9649c0937ead9c16524d3)

--------

See https://github.com/flatpak/flatpak/issues/3362 issue

The backport is necessary so that the bug doesn't manifest in our infra. @mwleeds pointed that we use our own fork of flatpak in some parts of the infrastructure. 

--------

Relevant discussions (for reference):
```
<uajain> Curious question : The fix https://github.com/flatpak/flatpak/pull/3369/files seems server-side so all flathub apps needs to be rebuilt to correct their sizes in their metadata?
<alexlarsson> barthalion: 1.6.1 in ppa now
<alexlarsson> uajain: yes
<alatiera> barthalion we will need to update the gnome builders that push to flathub as well
<alatiera> I think its gbm-builder
<alexlarsson> not necessarily
<alexlarsson> the size is recomputed in the publish job with build-commit-from
<alexlarsson> i believe
<alexlarsson> i mean, it won't hurt...
--> elstellino (~elstellin@185.58.208.7) has joined #flatpak
<alatiera> oh nice
<barthalion> alexlarsson: yeah, installed it yesterday
<alexlarsson> barthalion: well, some bogon caused the armv7 build to fail
<alexlarsson> barthalion: i retried it today and it succeeded
<alexlarsson> i guess we don't have any armv7 machines tho
<alexlarsson> so what you pulled yesterday should be fine?
<barthalion> does it matter? I thought it's calculated on flat-manager
<alexlarsson> true
<alexlarsson> generally nice to be on the same version everywhere tho
<alexlarsson> With the new permissions and whatnot
<alexlarsson> barthalion: oh, yeah, we want the new permission on the workers
<barthalion> ack
<alexlarsson> so update them too
<alexlarsson> So we can do jack apps
<barthalion> ah, right
<barthalion> caused so much havoc this week that I hoped not to touch anything on Friday, but maybe I'll get right at least this
<barthalion> uajain: I triggered new builds for affected apps in the morning
<barthalion> uajain: gnome and fdo folks will still need to push their runtimes but that should be it
<alexlarsson> Its weird that this is happening now though
<alexlarsson> that is an old bug
<alexlarsson> I guess it just happened to be zero most of the time before
<alexlarsson> and some random change made it not zero
<barthalion> I wasn't updating hub that often
<barthalion> more like never
<barthalion> so maybe the version was just old enough?
<alexlarsson> I don't think it ever worked
<uajain> barthalion: Thanks. wjt I am backporting the patch downstream and we need to do trigger new build for our eos-apps repo.
<barthalion> weird, some magic gcc flag that centos passes then? it was not happening at all for flathub builds
<alexlarsson> Well, "worked" 
<alexlarsson> the problem was it was counting the sizes
<alexlarsson> but the initial value of the counter was undefined
<alatiera> yay for UB
<alexlarsson> undefined could still be zero
<alexlarsson> or a small value
<alexlarsson> which would be ok
<barthalion> yeah, but it reliably started to be 94TB after we switched to ubuntu
<barthalion> and it was never that on centos
<alexlarsson> random changes in other code could make the initial value be something else
<barthalion> right
<alexlarsson> so, compiler differences, different flags, etc
<barthalion> done
```

@wjt checked today that on `dev` channel, installed and download sizes looks reasonable (i.e. not in **TBs**) so it is quite possible that the bug has not manifested itself yet on our infra, so a rebuilding of all the things might not be required for now.  

This backport is all about making the bug not to manifest in any near future either.

