### PR TITLE
Backport scratch deltas fixes

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4819,6 +4819,16 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
   if (extra_data_sources == NULL)
     {
+      /* This is a gigantic hack where we download the commit in a temporary transaction
+       * which we then abort after having read the result. We do this to avoid creating
+       * a partial commit in the local repo and a ref that points to it, because that
+       * causes ostree to not use static deltas.
+       * See https://github.com/flatpak/flatpak/issues/3412 for details.
+       */
+
+      if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
+        return FALSE;
+
       /* Pull the commits (and only the commits) to check for extra data
        * again. Here we don't pass the progress because we don't want any
        * reports coming out of it. */
@@ -4835,6 +4845,9 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
         return FALSE;
 
       extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
+
+      if (!ostree_repo_abort_transaction (repo, cancellable, error))
+        return FALSE;
     }
 
   n_extra_data = 0;
@@ -5484,9 +5497,6 @@ flatpak_dir_pull (FlatpakDir                           *self,
       g_ptr_array_add (subdirs_arg, NULL);
     }
 
-  if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
-    goto out;
-
   /* Setup extra data information before starting to pull, so we can have precise
    * progress reports */
   if (!flatpak_dir_setup_extra_data (self, repo, state->remote_name,
@@ -5495,6 +5505,10 @@ flatpak_dir_pull (FlatpakDir                           *self,
                                      progress,
                                      cancellable,
                                      error))
+    goto out;
+
+  /* Note, this has to start after setup_extra_data() because that also uses a transaction */
+  if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     goto out;
 
   flatpak_repo_resolve_rev (repo, state->collection_id, state->remote_name, ref, TRUE,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13459,7 +13459,7 @@ _flatpak_dir_fetch_remote_state_metadata_branch (FlatpakDir         *self,
           if (!flatpak_dir_pull (self, state, OSTREE_REPO_METADATA_REF, NULL, NULL, NULL,
                                  child_repo,
                                  flatpak_flags,
-                                 OSTREE_REPO_PULL_FLAGS_MIRROR,
+                                 0,
                                  progress, cancellable, error))
             return FALSE;
 


### PR DESCRIPTION
This backports the necessary fixes for https://github.com/flatpak/flatpak/issues/3412. This is basically the 1.4 backport in https://github.com/flatpak/flatpak/pull/3415 except that we already have `Revert "dir: Check commit signatures before resolving a ref"` and we don't actually want `Hardcode "python2" for tests` because master is based on 1.5.0 where the tests have already moved on to python3.

https://phabricator.endlessm.com/T29334