### PR TITLE
Add token-type per-commit metadata key and export it to summary

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -49,6 +49,7 @@ static char *opt_metadata;
 static char *opt_timestamp = NULL;
 static char *opt_endoflife;
 static char *opt_collection_id = NULL;
+static int opt_token_type = -1;
 
 static GOptionEntry options[] = {
   { "subject", 's', 0, G_OPTION_ARG_STRING, &opt_subject, N_("One line subject"), N_("SUBJECT") },
@@ -64,6 +65,7 @@ static GOptionEntry options[] = {
   { "include", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_include, N_("Excluded files to include"), N_("PATTERN") },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
   { "end-of-life", 0, 0, G_OPTION_ARG_STRING, &opt_endoflife, N_("Mark build as end-of-life"), N_("REASON") },
+  { "token-type", 0, 0, G_OPTION_ARG_INT, &opt_token_type, N_("Set type of token needed to install this commit"), N_("VAL") },
   { "timestamp", 0, 0, G_OPTION_ARG_STRING, &opt_timestamp, N_("Override the timestamp of the commit"), N_("TIMESTAMP") },
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), "COLLECTION-ID" },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
@@ -896,6 +898,10 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
   if (opt_endoflife && *opt_endoflife)
     g_variant_dict_insert_value (&metadata_dict, OSTREE_COMMIT_META_KEY_ENDOFLIFE,
                                  g_variant_new_string (opt_endoflife));
+
+  if (opt_token_type >= 0)
+    g_variant_dict_insert_value (&metadata_dict, "xa.token-type",
+                                 g_variant_new_int32 (opt_token_type));
 
   metadata_dict_v = g_variant_ref_sink (g_variant_dict_end (&metadata_dict));
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -63,6 +63,8 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_DEFAULT_UPDATE_FREQUENCY 100
 #define FLATPAK_CLI_UPDATE_FREQUENCY 300
 
+#define FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE "tokt"
+
 typedef struct
 {
   char    *collection_id;         /* (nullable) */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3103,6 +3103,7 @@ flatpak_repo_update (OstreeRepo   *repo,
       CommitData *rev_data;
       const char *eol = NULL;
       const char *eol_rebase = NULL;
+      int token_type = -1;
 
       /* See if we already have the info on this revision */
       if (g_hash_table_lookup (commit_data_cache, rev))
@@ -3143,7 +3144,8 @@ flatpak_repo_update (OstreeRepo   *repo,
 
       g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, "&s", &eol);
       g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, "&s", &eol_rebase);
-      if (eol || eol_rebase)
+      g_variant_lookup (commit_metadata, "xa.token-type", "i", &token_type);
+      if (eol || eol_rebase || token_type >= 0)
         {
           g_auto(GVariantBuilder) sparse_builder = FLATPAK_VARIANT_BUILDER_INITIALIZER;
           g_variant_builder_init (&sparse_builder, G_VARIANT_TYPE_VARDICT);
@@ -3151,6 +3153,8 @@ flatpak_repo_update (OstreeRepo   *repo,
             g_variant_builder_add (&sparse_builder, "{sv}", "eol", g_variant_new_string (eol));
           if (eol_rebase)
             g_variant_builder_add (&sparse_builder, "{sv}", "eolr", g_variant_new_string (eol_rebase));
+          if (token_type >= 0)
+            g_variant_builder_add (&sparse_builder, "{sv}", FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, g_variant_new_int32 (token_type));
 
           rev_data->sparse_data = g_variant_ref_sink (g_variant_builder_end (&sparse_builder));
         }


### PR DESCRIPTION
We store this in the sparse cache, because we don't expect it to be
set for everything.

(cherry picked from commit 077006ecc845e46a1a42d3721a2b1ebcb5572c7d)

Conflicts:
	app/flatpak-builtins-build-commit-from.c
	app/flatpak-builtins-build-export.c
	common/flatpak-dir-private.h
	common/flatpak-utils.c

The app conflicts were from the --end-of-life-rebase option not being
present in xenial version. The common conflicts were because the `eol`
and `eolr` cache keys had been turned into macros in
2db1c6e6c4219df182e95cf14205c728456782a0, but I just kept them in their
original form since that commit was much more widespread. The important
change here is to `flatpak_repo_update` to include the token type in the
summary metadata.

https://phabricator.endlessm.com/T26579