### PR TITLE
debian: Add dependency on eos-metrics-0-dev for downstream metrics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flatpak (1.6.2-1endless2) master; urgency=medium
+
+  * Add dependency on eos-metrics-0-dev for downstream metrics (T28742)
+
+ -- Philip Withnall <withnall@endlessm.com>  Mon, 23 Mar 2020 16:51:00 +0000
+
 flatpak (1.6.2-1endless1) master; urgency=medium
 
   * Rebase against Debian bullseye (T29218)

--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Build-Depends:
  dh-exec (>= 0.23~),
  docbook-xml <!nodoc>,
  docbook-xsl <!nodoc>,
+ eos-metrics-0-dev (>= 0.5.0),
  fuse <!nocheck>,
  gnupg <!nocheck>,
  gobject-introspection (>= 1.54.1-2~),


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28742

---

Code changes in #210 