### PR TITLE
T28651 Re-implement list_installed_refs_for_update()

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -919,10 +919,6 @@ GPtrArray * flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *se
                                                           GKeyFile           *metakey,
                                                           GCancellable       *cancellable,
                                                           GError            **error);
-gboolean    flatpak_dir_check_installed_ref_missing_related_ref (FlatpakDir          *self,
-                                                                 FlatpakRemoteState  *state,
-                                                                 const gchar         *full_ref,
-                                                                 GCancellable        *cancellable);
 GPtrArray * flatpak_dir_find_remote_related (FlatpakDir         *dir,
                                              FlatpakRemoteState *state,
                                              const char         *ref,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14232,42 +14232,6 @@ flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *self,
   return g_steal_pointer (&related);
 }
 
-gboolean
-flatpak_dir_check_installed_ref_missing_related_ref (FlatpakDir          *self,
-                                                     FlatpakRemoteState  *state,
-                                                     const gchar         *full_ref,
-                                                     GCancellable        *cancellable)
-{
-  g_autoptr(GPtrArray) remote_related_refs = NULL;
-  g_autoptr(GError) local_error = NULL;
-  guint j;
-
-  remote_related_refs = flatpak_dir_find_remote_related (self, state, full_ref,
-                                                         cancellable, &local_error);
-  if (remote_related_refs == NULL)
-    {
-      g_warning ("Unable to get remote related refs for %s: %s", full_ref, local_error->message);
-      return FALSE;
-    }
-
-  for (j = 0; j < remote_related_refs->len; j++)
-    {
-      FlatpakRelated *rel = g_ptr_array_index (remote_related_refs, j);
-      g_autoptr(GFile) deploy = NULL;
-
-      if (!rel->download || flatpak_dir_ref_is_masked (self, rel->ref))
-          continue;
-
-      deploy = flatpak_dir_get_if_deployed (self, rel->ref, NULL, cancellable);
-      /* If the related extension ref was meant to be auto-installed but was not found to be
-       * deployed, return TRUE. It will be pulled in via a FlatpakTransaction's update-op again. */
-      if (rel->download && deploy == NULL)
-          return TRUE;
-    }
-
-  return FALSE;
-}
-
 GPtrArray *
 flatpak_dir_find_remote_related (FlatpakDir         *self,
                                  FlatpakRemoteState *state,

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1946,6 +1946,7 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
   g_autofree char *origin = NULL;
   g_auto(GStrv) parts = NULL;
+  g_auto(GStrv) merged_subpaths = NULL;
   const char *pref;
   g_autofree char *origin_remote = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
@@ -1985,7 +1986,9 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
   /* install or update */
   if (kind == FLATPAK_TRANSACTION_OPERATION_UPDATE)
     {
-      if (!dir_ref_is_installed (priv->dir, ref, &origin, NULL))
+      g_autoptr(GVariant) deploy_data = NULL;
+
+      if (!dir_ref_is_installed (priv->dir, ref, &origin, &deploy_data))
         return flatpak_fail_error (error, FLATPAK_ERROR_NOT_INSTALLED,
                                    _("%s not installed"), pref);
 
@@ -1995,6 +1998,18 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
           return TRUE;
         }
       remote = origin;
+
+      /* As stated in the documentation for flatpak_transaction_add_update(),
+       * for locale extensions we merge existing subpaths with the set of
+       * configured languages, to match the behavior of add_related().
+       */
+      if (subpaths == NULL && g_str_has_suffix (parts[1], ".Locale"))
+        {
+          g_autofree const char **old_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
+          g_auto(GStrv) extra_subpaths = flatpak_dir_get_locale_subpaths (priv->dir);
+          merged_subpaths = flatpak_subpaths_merge ((char **)old_subpaths, extra_subpaths);
+          subpaths = (const char **)merged_subpaths;
+        }
     }
   else if (kind == FLATPAK_TRANSACTION_OPERATION_INSTALL)
     {
@@ -2179,7 +2194,8 @@ flatpak_transaction_add_install_flatpakref (FlatpakTransaction *self,
  * @self: a #FlatpakTransaction
  * @ref: the ref
  * @subpaths: (nullable) (array zero-terminated=1): subpaths to install; %NULL
- *  to use the current set, or `{ "", NULL }` to pull all subpaths.
+ *  to use the current set plus the set of configured languages, or
+ *  `{ "", NULL }` to pull all subpaths.
  * @commit: (nullable): the commit to update to, or %NULL to use the latest
  * @error: return location for a #GError
  *
@@ -2202,6 +2218,7 @@ flatpak_transaction_add_update (FlatpakTransaction *self,
   if (subpaths != NULL && subpaths[0] != NULL && subpaths[0][0] == 0)
     subpaths = all_paths;
 
+  /* Note: we implement the merge when subpaths == NULL in flatpak_transaction_add_ref() */
   return flatpak_transaction_add_ref (self, NULL, ref, subpaths, NULL, commit, FLATPAK_TRANSACTION_OPERATION_UPDATE, NULL, NULL, error);
 }
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3278,7 +3278,7 @@ sort_ops (FlatpakTransaction *self)
   priv->ops = NULL;
 
   /* First mark runnable all jobs that depend on nothing.
-     Note that this seesntially reverses the original list, so these
+     Note that this essentially reverses the original list, so these
      are in the same order as specified */
   for (l = remaining; l != NULL; l = next)
     {

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -125,6 +125,7 @@ struct _FlatpakTransactionOperation
   int                             run_after_prio; /* Higher => run later (when it becomes runnable). Used to run related ops (runtime extensions) before deps (apps using the runtime) */
   GList                          *run_before_ops;
   FlatpakTransactionOperation    *fail_if_op_fails; /* main app/runtime for related extensions, runtime for apps */
+  FlatpakTransactionOperation    *related_to_op; /* main app/runtime for related extensions, app for runtimes */
 };
 
 typedef struct _FlatpakTransactionPrivate FlatpakTransactionPrivate;
@@ -646,6 +647,26 @@ const char *
 flatpak_transaction_operation_get_ref (FlatpakTransactionOperation *self)
 {
   return self->ref;
+}
+
+/**
+ * flatpak_transaction_operation_get_related_to_op:
+ * @self: a #FlatpakTransactionOperation
+ *
+ * Gets the operation which caused this operation to be added to the
+ * transaction. In the case of a runtime, it's the app whose runtime it is. In
+ * the case of a related ref such as an extension, it's the main app or
+ * runtime. In the case of a main app or something added to the transaction by
+ * flatpak_transaction_add_ref(), %NULL will be returned.
+ *
+ * Returns: (transfer none) (nullable): the #FlatpakTransactionOperation this
+ *   one is related to, or %NULL
+ * Since: 1.7.3
+ */
+FlatpakTransactionOperation *
+flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *self)
+{
+  return self->related_to_op;
 }
 
 /**
@@ -1745,6 +1766,7 @@ add_related (FlatpakTransaction          *self,
                                                    FLATPAK_TRANSACTION_OPERATION_UNINSTALL);
           related_op->non_fatal = TRUE;
           related_op->fail_if_op_fails = op;
+          related_op->related_to_op = op;
           run_operation_before (op, related_op, 1);
         }
     }
@@ -1764,6 +1786,7 @@ add_related (FlatpakTransaction          *self,
                                                    FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);
           related_op->non_fatal = TRUE;
           related_op->fail_if_op_fails = op;
+          related_op->related_to_op = op;
           run_operation_before (related_op, op, 1);
         }
     }
@@ -1901,6 +1924,7 @@ add_deps (FlatpakTransaction          *self,
                                    runtime_op->ref, op->ref);
 
       op->fail_if_op_fails = runtime_op;
+      runtime_op->related_to_op = op;
       run_operation_before (runtime_op, op, 2);
     }
 

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -174,6 +174,8 @@ FlatpakTransactionOperationType flatpak_transaction_operation_get_operation_type
 FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_ref (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
+FlatpakTransactionOperation *   flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *self);
+FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_remote (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 GFile *                         flatpak_transaction_operation_get_bundle_path (FlatpakTransactionOperation *self);

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -863,6 +863,12 @@ gboolean flatpak_repo_resolve_rev (OstreeRepo    *repo,
                                    GCancellable  *cancellable,
                                    GError       **error);
 
+static inline void
+null_safe_g_object_unref (gpointer data)
+{
+  g_clear_object (&data);
+}
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -198,7 +198,7 @@ tests/test-%.wrap:
 
 tests/runtime-repo: tests/make-test-runtime.sh flatpak
 	rm -rf tests/runtime-repo
-	PATH=$(abs_top_builddir):$${PATH} $(top_srcdir)/tests/make-test-runtime.sh tests/runtime-repo org.test.Platform master ""
+	PATH=$(abs_top_builddir):$${PATH} $(top_srcdir)/tests/make-test-runtime.sh tests/runtime-repo org.test.Platform master "" ""
 
 check_DATA += tests/runtime-repo
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -223,7 +223,7 @@ make_runtime () {
         (
             flock -s 200
             if [ ! -d ${RUNTIME_REPO} ]; then
-                $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform ${BRANCH} "" > /dev/null
+                $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform ${BRANCH} "" "" > /dev/null
             fi
         ) 200>${TEST_DATA_DIR}/runtime-repo-lock
     fi
@@ -324,7 +324,7 @@ setup_sdk_repo () {
     fi
     BRANCH=${3:-master}
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${BRANCH}" "${COLLECTION_ID}" make mkdir cp touch > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${BRANCH}" "${COLLECTION_ID}" "" make mkdir cp touch > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -16,6 +16,9 @@ shift
 COLLECTION_ID=$1
 shift
 
+EXTRA="${1-}"
+shift
+
 mkdir ${DIR}/files
 mkdir ${DIR}/usr
 cat > ${DIR}/metadata <<EOF
@@ -73,6 +76,13 @@ for i in `cat $LIBS`; do
     cp "$i" ${DIR}/usr/lib/
 done
 ln -s bash ${DIR}/usr/bin/sh
+
+# This only exists so we can update the runtime
+cat > ${DIR}/usr/bin/runtime_hello.sh <<EOF
+#!/bin/sh
+echo "Hello world, from a runtime$EXTRA"
+EOF
+chmod a+x ${DIR}/usr/bin/runtime_hello.sh
 
 # We copy the C.UTF8 locale and call it en_US. Its a bit of a lie, but
 # the real en_US locale is often not available, because its in the

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -95,7 +95,7 @@ EOF
 
 mkdir -p repos
 ostree init --repo=repos/test --mode=archive-z2
-$(dirname $0)/make-test-runtime.sh repos/test org.test.Platform master "" bash ls cat echo readlink > /dev/null
+$(dirname $0)/make-test-runtime.sh repos/test org.test.Platform master "" "" bash ls cat echo readlink > /dev/null
 $(dirname $0)/make-test-app.sh repos/test "" master "" > /dev/null
 
 # Modify platform metadata

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1895,21 +1895,7 @@ test_list_updates (void)
                       "hello-again.desktop;net.example.Goodbye.Again.desktop;");
 
   /* Uninstall the runtime and app */
-  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_nonnull (transaction);
-
-  res = flatpak_transaction_add_uninstall (transaction, app, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
-
-  res = flatpak_transaction_add_uninstall (transaction, runtime, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
-
-  res = flatpak_transaction_run (transaction, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
+  empty_installation (inst);
 }
 
 static void

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -239,11 +239,11 @@ test_installation_config (void)
 }
 
 static void
-configure_languages (void)
+configure_languages (const char *lang)
 {
-  char *argv[] = { "flatpak", "config", "--user", "--set", "languages", "de", NULL };
+  const char *argv[] = { "flatpak", "config", "--user", "--set", "languages", lang, NULL };
 
-  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
+  run_test_subprocess ((char **)argv, RUN_TEST_SUBPROCESS_DEFAULT);
 }
 
 static void
@@ -333,7 +333,7 @@ test_languages_config (void)
 
   g_clear_pointer (&value, g_strfreev);
   clean_extra_languages ();
-  configure_languages ();
+  configure_languages ("de");
 }
 
 static void
@@ -1154,10 +1154,12 @@ test_update_related_refs (void)
   g_autoptr(GPtrArray) updatable_refs = NULL;
   g_autoptr(GPtrArray) related_refs = NULL;
   g_autoptr(GError) error = NULL;
-  FlatpakInstalledRef *iref = NULL;
+  g_autoptr(FlatpakInstalledRef) iref = NULL;
   g_autoptr(FlatpakInstalledRef) runtime_ref = NULL;
   gboolean res;
   g_autofree char *app = NULL;
+  g_autofree char *app_locale = NULL;
+  const char * const *subpaths;
 
   app = g_strdup_printf ("app/org.test.Hello/%s/master",
                          flatpak_get_default_arch ());
@@ -1186,13 +1188,14 @@ test_update_related_refs (void)
 				                               &error);
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_INSTALLED_REF (iref));
-  iref = NULL;
+  g_clear_object (&iref);
 
   /* We expect no installed related refs (i.e. org.test.Hello.Locale) at this point */
   related_refs = flatpak_installation_list_installed_related_refs_sync (inst, repo_name, app, NULL, &error);
   g_assert_cmpint (related_refs->len, ==, 0);
 
   updatable_refs = flatpak_installation_list_installed_refs_for_update (inst, NULL, &error);
+  g_assert_no_error (error);
   g_assert_cmpint (updatable_refs->len, ==, 1);
   iref = g_ptr_array_index (updatable_refs, 0);
   g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (iref)), ==, "org.test.Hello");
@@ -1214,6 +1217,58 @@ test_update_related_refs (void)
   iref = flatpak_installation_get_installed_ref (inst, FLATPAK_REF_KIND_RUNTIME, "org.test.Hello.Locale", NULL, NULL, NULL, &error);
   g_assert_nonnull (iref);
   g_assert_no_error (error);
+
+  /* Now check that when we have only subpaths of the locale extension
+   * installed and we change the configured languages, it shows as needing an
+   * update.
+   */
+  subpaths = flatpak_installed_ref_get_subpaths (iref);
+  g_assert_cmpint (g_strv_length ((char **) subpaths), ==, 1);
+  g_assert_cmpstr (subpaths[0], ==, "/de");
+  g_clear_object (&iref);
+
+  configure_languages ("es");
+  flatpak_installation_drop_caches (inst, NULL, &error);
+  g_assert_no_error (error);
+
+  g_clear_pointer (&updatable_refs, g_ptr_array_unref);
+  updatable_refs = flatpak_installation_list_installed_refs_for_update (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (updatable_refs->len, ==, 1);
+  iref = g_ptr_array_index (updatable_refs, 0);
+  g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (iref)), ==, "org.test.Hello.Locale");
+
+  /* Now update org.test.Hello.Locale and check that the subpaths are updated. */
+  g_clear_object (&transaction);
+  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (transaction);
+
+  app_locale = g_strdup_printf ("runtime/org.test.Hello.Locale/%s/master",
+                                flatpak_get_default_arch ());
+
+  res = flatpak_transaction_add_update (transaction, app_locale, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  res = flatpak_transaction_run (transaction, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  flatpak_installation_drop_caches (inst, NULL, &error);
+  g_assert_no_error (error);
+  iref = flatpak_installation_get_installed_ref (inst, FLATPAK_REF_KIND_RUNTIME, "org.test.Hello.Locale", NULL, NULL, NULL, &error);
+  g_assert_nonnull (iref);
+  g_assert_no_error (error);
+
+  subpaths = flatpak_installed_ref_get_subpaths (iref);
+  g_assert_cmpint (g_strv_length ((char **) subpaths), ==, 2);
+  g_assert_cmpstr (subpaths[0], ==, "/de");
+  g_assert_cmpstr (subpaths[1], ==, "/es");
+
+  /* Reset things */
+  configure_languages ("de");
+  empty_installation (inst);
 }
 
 static void
@@ -1297,8 +1352,8 @@ test_list_remote_related_refs (void)
   g_assert_true (should_delete);
   g_assert_false (should_autoprune);
 
-  configure_languages();
-  clean_extra_languages();
+  configure_languages ("de");
+  clean_extra_languages ();
 }
 
 static void
@@ -1555,6 +1610,7 @@ test_install_launch_uninstall (void)
 }
 
 static void update_test_app (void);
+static void update_test_runtime (void);
 static void update_repo (const char *update_repo_name);
 
 static const char *
@@ -1798,8 +1854,9 @@ test_list_updates (void)
   /* Add a previous-id to the deploy file */
   mangle_deploy_file (ref);
 
-  /* Update the test app and list the update */
+  /* Update the test app and the runtime and list the updates */
   update_test_app ();
+  update_test_runtime ();
   update_repo ("test");
 
   /* Drop all in-memory summary caches so we can find the new update */
@@ -1809,15 +1866,18 @@ test_list_updates (void)
   refs = flatpak_installation_list_installed_refs_for_update (inst, NULL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (refs);
-  g_assert_cmpint (refs->len, ==, 2);
+  g_assert_cmpint (refs->len, ==, 3);
   update_ref = g_ptr_array_index (refs, 0);
   g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Hello");
   g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_APP);
   update_ref = g_ptr_array_index (refs, 1);
   g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Hello.Locale");
   g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_RUNTIME);
+  update_ref = g_ptr_array_index (refs, 2);
+  g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Platform");
+  g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_RUNTIME);
 
-  /* Install the new update */
+  /* Install the app update */
   updated_ref = flatpak_installation_update (inst,
                                              FLATPAK_UPDATE_FLAGS_NONE,
                                              FLATPAK_REF_KIND_APP,
@@ -1850,6 +1910,82 @@ test_list_updates (void)
   res = flatpak_transaction_run (transaction, NULL, &error);
   g_assert_no_error (error);
   g_assert_true (res);
+}
+
+static void
+test_list_undeployed_updates (void)
+{
+  g_autoptr(FlatpakInstallation) inst = NULL;
+  g_autoptr(FlatpakTransaction) transaction = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GPtrArray) refs = NULL;
+  FlatpakInstalledRef *update_ref = NULL;
+  g_autoptr(FlatpakInstalledRef) updated_ref = NULL;
+  g_autofree gchar *app = NULL;
+  gboolean res;
+
+  app = g_strdup_printf ("app/org.test.Hello/%s/master",
+                         flatpak_get_default_arch ());
+
+  inst = flatpak_installation_new_user (NULL, &error);
+  g_assert_no_error (error);
+
+  empty_installation (inst);
+
+  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (transaction);
+
+  /* install org.test.Hello, and have org.test.Hello.Locale and org.test.Platform
+   * added as deps/related
+   */
+  res = flatpak_transaction_add_install (transaction, repo_name, app, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  res = flatpak_transaction_run (transaction, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+  g_clear_object (&transaction);
+
+  refs = flatpak_installation_list_installed_refs (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (refs);
+  g_assert_cmpint (refs->len, ==, 3);
+  g_clear_pointer (&refs, g_ptr_array_unref);
+
+  update_test_app ();
+  update_repo ("test");
+
+  /* Drop all in-memory summary caches so we can find the new update */
+  flatpak_installation_drop_caches (inst, NULL, &error);
+  g_assert_no_error (error);
+
+  /* Install the app update but don't deploy it */
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  updated_ref = flatpak_installation_update (inst,
+                                             FLATPAK_UPDATE_FLAGS_NO_DEPLOY,
+                                             FLATPAK_REF_KIND_APP,
+                                             "org.test.Hello",
+                                             flatpak_get_default_arch (), "master",
+                                             NULL, NULL, NULL, &error);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+  g_assert_no_error (error);
+  g_assert_true (FLATPAK_IS_INSTALLED_REF (updated_ref));
+
+  refs = flatpak_installation_list_installed_refs_for_update (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (refs);
+  g_assert_cmpint (refs->len, ==, 2);
+  update_ref = g_ptr_array_index (refs, 0);
+  g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Hello");
+  g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_APP);
+  update_ref = g_ptr_array_index (refs, 1);
+  g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (update_ref)), ==, "org.test.Hello.Locale");
+  g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (update_ref)), ==, FLATPAK_REF_KIND_RUNTIME);
+
+  /* Uninstall the runtime and app */
+  empty_installation (inst);
 }
 
 static void
@@ -1990,7 +2126,7 @@ make_test_runtime (const char *runtime_repo_name)
   g_autofree char *arg0 = NULL;
   g_autofree char *arg1 = NULL;
   char *argv[] = {
-    NULL, NULL, "org.test.Platform", "master", "", NULL
+    NULL, NULL, "org.test.Platform", "master", "", "", NULL
   };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);
@@ -2025,6 +2161,19 @@ update_test_app (void)
   char *argv[] = { NULL, "repos/test", "", "master", "", "SPIN", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
+  argv[0] = arg0;
+  argv[4] = repo_collection_id;
+
+  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
+}
+
+static void
+update_test_runtime (void)
+{
+  g_autofree char *arg0 = NULL;
+  char *argv[] = { NULL, "repos/test", "org.test.Platform", "master", "", "UPDATED", NULL };
+
+  arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);
   argv[0] = arg0;
   argv[4] = repo_collection_id;
 
@@ -2215,7 +2364,7 @@ setup_repo (void)
   launch_httpd ();
   add_remote_user ("test");
   add_flatpakrepo ("test");
-  configure_languages ();
+  configure_languages ("de");
 
   /* another copy of the same repo, with different url */
   g_assert_cmpint (symlink ("test", "repos/copy-of-test"), ==, 0);
@@ -3871,8 +4020,8 @@ test_list_installed_related_refs (void)
   g_assert_cmpstr (flatpak_related_ref_get_subpaths (ref)[0], ==, "/de");
   g_assert_cmpstr (flatpak_related_ref_get_subpaths (ref)[1], ==, "/en");
 
-  configure_languages();
-  clean_extra_languages();
+  configure_languages ("de");
+  clean_extra_languages ();
 }
 
 static void
@@ -4076,6 +4225,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/library/install-launch-uninstall", test_install_launch_uninstall);
   g_test_add_func ("/library/list-refs-in-remote", test_list_refs_in_remotes);
   g_test_add_func ("/library/list-updates", test_list_updates);
+  g_test_add_func ("/library/list-undeployed-updates", test_list_undeployed_updates);
   g_test_add_func ("/library/list-updates-offline", test_list_updates_offline);
   g_test_add_func ("/library/transaction", test_misc_transaction);
   g_test_add_func ("/library/transaction-install-uninstall", test_transaction_install_uninstall);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1185,7 +1185,7 @@ test_update_related_refs (void)
                                        FLATPAK_REF_KIND_APP,
                                        "org.test.Hello",
                                        NULL, "master", NULL, NULL, NULL,
-				                               &error);
+                                       &error);
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_INSTALLED_REF (iref));
   g_clear_object (&iref);


### PR DESCRIPTION
These are cherry-picks from https://github.com/flatpak/flatpak/pull/3537

There were some merge conflicts in "installation: Re-implement list_installed_refs_for_update()" but otherwise pretty uneventful.

Given the 3.8.0 schedule, I think we should merge this without waiting for upstream.

https://phabricator.endlessm.com/T28651