### PR TITLE
dir: Fix memory errors in use of deploy variant

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -680,6 +680,12 @@ flatpak_load_deploy_data (GFile        *deploy_dir,
   if (flatpak_deploy_data_get_version (deploy_data) < required_version)
     return upgrade_deploy_data (deploy_data, deploy_dir, ref);
 
+  /* Call g_variant_get_data() to serialize the GVariant internally, because
+   * during serialization the children are freed, and we need values from the
+   * children to remain valid for the lifetime of the GVariant since we use
+   * them in e.g. flatpak_deploy_data_get_string().
+   */
+  g_variant_get_data (deploy_data);
   return g_steal_pointer (&deploy_data);
 }
 
@@ -2682,6 +2688,7 @@ static GVariant *
 upgrade_deploy_data (GVariant *deploy_data, GFile *deploy_dir, const char *ref)
 {
   g_autoptr(GVariant) metadata = g_variant_get_child_value (deploy_data, 4);
+  g_autoptr(GVariant) upgraded_data = NULL;
   GVariantBuilder metadata_builder;
   g_autofree const char **subpaths = NULL;
   int i, n, old_version;
@@ -2713,12 +2720,20 @@ upgrade_deploy_data (GVariant *deploy_data, GFile *deploy_dir, const char *ref)
     }
 
   subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
-  return g_variant_ref_sink (g_variant_new ("(ss^ast@a{sv})",
-                                            flatpak_deploy_data_get_origin (deploy_data),
-                                            flatpak_deploy_data_get_commit (deploy_data),
-                                            subpaths,
-                                            GUINT64_TO_BE (flatpak_deploy_data_get_installed_size (deploy_data)),
-                                            g_variant_builder_end (&metadata_builder)));
+  upgraded_data = g_variant_ref_sink (g_variant_new ("(ss^ast@a{sv})",
+                                      flatpak_deploy_data_get_origin (deploy_data),
+                                      flatpak_deploy_data_get_commit (deploy_data),
+                                      subpaths,
+                                      GUINT64_TO_BE (flatpak_deploy_data_get_installed_size (deploy_data)),
+                                      g_variant_builder_end (&metadata_builder)));
+
+  /* Call g_variant_get_data() to serialize the GVariant internally, because
+   * during serialization the children are freed, and we need values from the
+   * children to remain valid for the lifetime of the GVariant since we use
+   * them in e.g. flatpak_deploy_data_get_string().
+   */
+  g_variant_get_data (upgraded_data);
+  return g_steal_pointer (&upgraded_data);
 }
 
 GVariant *


### PR DESCRIPTION
In the implementation of flatpak_deploy_data_get_string() and a few
other getters, we borrow a value from a GVariant that is a child of the
main GVariant, and free the child via g_autoptr(). Since we then no
longer hold a reference to the child variant, if it is freed internally
in GLib, the borrowed value is no longer safe to access. And GLib frees
all children of a GVariant when serializing it; see the implementation
of g_variant_get_data().

Therefore, in the implementation of the list command the value returned
by flatpak_deploy_data_get_runtime() is not valid after
flatpak_deploy_data_get_origin() is called, and the end result is that
the values in the runtime column of the output are sometimes gibberish.

For now, fix it by ensuring that the GVariant for deploy data is
serialized directly after it is created. Next time we rebase this code
will all go away because it has been replaced upstream with use of
variant-schema-compiler, and this issue is not present in that case
according to valgrind.

See also https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1462

https://phabricator.endlessm.com/T29945