### PR TITLE
dir: don't disable Kolibri's search provider

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6582,7 +6582,9 @@ export_ini_file (int                 parent_fd,
     {
       g_autofree gchar *bus_name = g_key_file_get_string (keyfile, "Shell Search Provider", "BusName", NULL);
 
-      if (bus_name == NULL || !g_str_has_prefix (bus_name, "com.endlessm."))
+      if (bus_name == NULL ||
+          (!g_str_has_prefix (bus_name, "com.endlessm.") &&
+           !g_str_equal (bus_name, "org.learningequality.Kolibri.SearchProvider")))
         g_key_file_set_boolean (keyfile, "Shell Search Provider", "DefaultDisabled", TRUE);
     }
 


### PR DESCRIPTION
The Flatpak upstream behaviour is to disable search providers by
default:

> Installing a search provider is a minor security issue, as it
> can see all that you search for in the desktop

Kolibri's search provider queries a local database, so does not pose a
security risk. We trust Learning Equality not to change this.

https://phabricator.endlessm.com/T28681