### PR TITLE
eos: Allow metrics to be optional

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -42,7 +42,9 @@
 #include <gio/gunixsocketaddress.h>
 #include <ostree.h>
 
+#ifdef HAVE_EOSMETRICS
 #include <eosmetrics/eosmetrics.h>
+#endif
 
 #ifdef USE_SYSTEM_HELPER
 #include <polkit/polkit.h>
@@ -7823,6 +7825,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
 
   if (!authorized)
     {
+#ifdef HAVE_EOSMETRICS
       /* Send a metrics event so we have an idea if there are any places which
        * don’t block app installing from the UI. If everything is implemented
        * correctly, this event should never be submitted (apart from when the
@@ -7833,6 +7836,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
       emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
                                         FLATPAK_PARENTAL_CONTROLS_INSTALL_EVENT,
                                         g_variant_new_string (ref));
+#endif  /* HAVE_EOSMETRICS */
 
       return flatpak_fail_error (error, FLATPAK_ERROR_PERMISSION_DENIED,
                                 /* Translators: The placeholder is for an app ref. */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -22,7 +22,6 @@
 
 #include <string.h>
 #include <ctype.h>
-#include <eosmetrics/eosmetrics.h>
 #include <fcntl.h>
 #include <gio/gdesktopappinfo.h>
 #include <stdio.h>
@@ -37,6 +36,9 @@
 #include <gio/gunixfdlist.h>
 #ifdef HAVE_DCONF
 #include <dconf/dconf.h>
+#endif
+#ifdef HAVE_EOSMETRICS
+#include <eosmetrics/eosmetrics.h>
 #endif
 #ifdef HAVE_LIBMALCONTENT
 #include <libmalcontent/malcontent.h>
@@ -3401,6 +3403,7 @@ check_parental_controls (const char     *app_ref,
 
   if (!allowed)
     {
+#ifdef HAVE_EOSMETRICS
       /* Send a metrics event so we have an idea if there are any places which
        * don’t block app launching from the UI. If everything is implemented
        * correctly, this event should never be submitted (apart from when the
@@ -3411,6 +3414,7 @@ check_parental_controls (const char     *app_ref,
       emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
                                         FLATPAK_PARENTAL_CONTROLS_RUN_EVENT,
                                         g_variant_new_string (app_ref));
+#endif  /* HAVE_EOSMETRICS */
 
       return flatpak_fail_error (error, FLATPAK_ERROR_PERMISSION_DENIED,
                                  /* Translators: The placeholder is for an app ref. */

--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,11 @@ PKG_CHECK_MODULES(GLIB260, glib-2.0 >= 2.60,
                   [AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, GLIB_VERSION_2_60, [Ignore massive GTimeVal deprecation warnings in 2.62])],
                   [true])
 
-PKG_CHECK_MODULES([EOSMETRICS], [eosmetrics-0 >= 0.5.0])
+PKG_CHECK_MODULES([EOSMETRICS], [eosmetrics-0 >= 0.5.0],
+                  [have_eosmetrics=yes], [have_eosmetrics=no])
+AS_IF([test "$have_eosmetrics" = yes], [
+  AC_DEFINE([HAVE_EOSMETRICS], [1], [Define if eosmetrics-0 is available])
+])
 
 save_LIBS=$LIBS
 LIBS=$ARCHIVE_LIBS
@@ -548,4 +552,5 @@ echo "          Privilege mode:         $with_priv_mode"
 echo "          Use dconf:              $have_dconf"
 echo "          Use libsystemd:         $have_libsystemd"
 echo "          Use libmalcontent:      $have_libmalcontent"
+echo "          Use eosmetrics:         $have_eosmetrics"
 echo ""


### PR DESCRIPTION
We'd like to use the same flatpak on our infrastructure so that it
captures any Endless deviations such as handling of search providers.
However, eosmetrics isn't available on our Debian based systems and
wouldn't actually be used there.

This should not be upstreamed and can be folded into "eos: Add metrics
submission on parental controls blocking run/install" on the next
rebase.

https://phabricator.endlessm.com/T30099