### PR TITLE
transaction: Don't add deps or related for skipped ops

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -4018,7 +4018,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
     {
       FlatpakTransactionOperation *op = l->data;
 
-      if (!add_deps (self, op, error))
+      if (!op->skip && !add_deps (self, op, error))
         return FALSE;
     }
 
@@ -4031,7 +4031,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
     {
       FlatpakTransactionOperation *op = l->data;
 
-      if (!add_related (self, op, error))
+      if (!op->skip && !add_related (self, op, error))
         return FALSE;
     }
 


### PR DESCRIPTION
Currently in the FlatpakTransaction implementation we add dependencies
and related refs for each operation in the transaction regardless of if
it's skipped or not. This is an issue in the case of an
end-of-life-rebased ref because in that case if the user agrees a new
install operation is added for the new ref, an uninstall operation is
added for the end-of-lifed ref, and the update operation for the
end-of-lifed one is marked as to be skipped. Then the dependencies of
the end-of-lifed ref get added to the transaction and ultimately after
all the sorting is done you end up with duplicate operations. In the
case of having org.gnome.tetravex installed, "flatpak update" yields a
transaction which uninstalls org.gnome.tetravex.Locale twice and errors
out on the second time (in addition to uninstalling org.gnome.tetravex
and installing org.gnome.Tetravex and org.gnome.Tetravex.Locale).

Fix the issue by skipping operations marked as to be skipped when adding
dependencies and related refs to the transaction.

(cherry picked from commit e83ff0ca8515ca4db4f9acfcb2be6052de22efdf)

https://phabricator.endlessm.com/T30340