### PR TITLE
dir: Fix an error path with unset GError

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4013,7 +4013,7 @@ flatpak_dir_prepare_resolve_p2p_refs_helper (FlatpakDir             *self,
       if (resolve->local_commit == NULL || latest_rev == NULL)
         continue;
 
-      if (!ostree_repo_load_commit (state->child_repo, resolve->local_commit, &commit_data, NULL, NULL))
+      if (!ostree_repo_load_commit (state->child_repo, resolve->local_commit, &commit_data, NULL, error))
         return FALSE;
 
       local_timestamp = ostree_commit_get_timestamp (commit_data);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3998,20 +3998,35 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
 
   if (!priv->no_pull &&
       !flatpak_transaction_update_metadata (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   if (!flatpak_transaction_add_auto_install (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   if (!flatpak_transaction_resolve_flatpakrefs (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   if (!flatpak_transaction_resolve_bundles (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   /* Resolve initial ops */
   if (!resolve_all_ops (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   /* Add all app -> runtime dependencies */
   for (l = priv->ops; l != NULL; l = l->next)
@@ -4019,12 +4034,18 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
       FlatpakTransactionOperation *op = l->data;
 
       if (!op->skip && !add_deps (self, op, error))
-        return FALSE;
+        {
+          g_assert (error == NULL || *error != NULL);
+          return FALSE;
+        }
     }
 
   /* Resolve new ops */
   if (!resolve_all_ops (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   /* Add all related extensions */
   for (l = priv->ops; l != NULL; l = l->next)
@@ -4032,16 +4053,25 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
       FlatpakTransactionOperation *op = l->data;
 
       if (!op->skip && !add_related (self, op, error))
-        return FALSE;
+        {
+          g_assert (error == NULL || *error != NULL);
+          return FALSE;
+        }
     }
 
   /* Resolve new ops */
   if (!resolve_all_ops (self, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   /* Ensure we have all required tokens */
   if (!request_required_tokens (self, NULL, cancellable, error))
-    return FALSE;
+    {
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
+    }
 
   sort_ops (self);
 


### PR DESCRIPTION
This fixes a place where we omit passing a GError pointer and therefore
potentially return FALSE without setting the passed in error. This
causes flatpak_installation_list_installed_refs_for_update() to hit an
assertion failure, crashing libflatpak (and subsequently the App Center
when it's used).

The debug log provided by the user shows messages being printed from
flatpak_dir_prepare_resolve_p2p_refs_helper() for only a subset of the
refs being resolved, and then the log stops since the process crashes,
so that's how I know with near certainty that this patch fixes the
crash experienced by the user on the forum.

The upstream PR on the flatpak-1.6.x branch is here:
https://github.com/flatpak/flatpak/pull/3691

https://phabricator.endlessm.com/T30340