### PR TITLE
Backport bug fixes from 1.9.x

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -271,10 +271,10 @@ flatpak_builtin_enter (int           argc,
 
   session_bus_path = g_strdup_printf ("/run/user/%d/bus", uid);
   if (g_file_test (session_bus_path, G_FILE_TEST_EXISTS))
-    g_ptr_array_add (envp_array, g_strdup_printf ("DBUS_SESSION_BUS_ADDRESS=unix:%s", session_bus_path));
+    g_ptr_array_add (envp_array, g_strdup_printf ("DBUS_SESSION_BUS_ADDRESS=unix:path=%s", session_bus_path));
 
   if (g_file_test ("/run/dbus/system_bus_socket", G_FILE_TEST_EXISTS))
-    g_ptr_array_add (envp_array, g_strdup ("DBUS_SYSTEM_BUS_ADDRESS=unix:/run/dbus/system_bus_socket"));
+    g_ptr_array_add (envp_array, g_strdup ("DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket"));
 
   g_ptr_array_add (envp_array, NULL);
 

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -145,7 +145,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   if (deploy_data == NULL)
     return FALSE;
 
-  deploy = flatpak_find_deploy_for_ref (ref, NULL, NULL, error);
+  deploy = flatpak_dir_load_deployed (dir, ref, NULL, cancellable, error);
   if (deploy == NULL)
     return FALSE;
 
@@ -406,12 +406,10 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
 
       if (opt_show_metadata)
         {
-          g_autoptr(GFile) deploy_dir = NULL;
           g_autoptr(GFile) file = NULL;
           g_autofree char *data = NULL;
           gsize data_size;
 
-          deploy_dir = flatpak_dir_get_if_deployed (dir, ref, NULL, cancellable);
           file = g_file_get_child (deploy_dir, "metadata");
 
           if (!g_file_load_contents (file, cancellable, &data, &data_size, NULL, error))

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -222,8 +222,6 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
 
           commit_metadata = var_commit_get_metadata (commit);
           xa_metadata = var_metadata_lookup_string (commit_metadata, "xa.metadata", NULL);
-          if (xa_metadata == NULL)
-            g_printerr (_("Warning: Commit has no flatpak metadata\n"));
 
           if (xa_metadata == NULL)
             g_printerr (_("Warning: Commit has no flatpak metadata\n"));

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -998,14 +998,14 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
 
   /* First try local availability */
   if (ostree_repo_load_commit (dir->repo, commit, &commit_data, NULL, NULL))
-    return g_steal_pointer (&commit_data);
+    goto out;
 
   for (int i = 0; i < self->sideload_repos->len; i++)
     {
       FlatpakSideloadState *ss = g_ptr_array_index (self->sideload_repos, i);
 
       if (ostree_repo_load_commit (ss->repo, commit, &commit_data, NULL, NULL))
-        return g_steal_pointer (&commit_data);
+        goto out;
     }
 
   if (flatpak_dir_get_remote_oci (dir, self->remote_name))
@@ -1015,6 +1015,7 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
                                                             cancellable, error);
 
+out:
   if (out_commit)
     *out_commit = g_steal_pointer (&commit);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7447,6 +7447,8 @@ apply_extra_data (FlatpakDir   *self,
                           NULL);
 
   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, NULL, runtime_ref_parts[2],
+                                    /* Might need multiarch in apply_extra (see e.g. #3742). Should be pretty safe in this limited context */
+                                    FLATPAK_RUN_FLAG_MULTIARCH |
                                     FLATPAK_RUN_FLAG_NO_SESSION_HELPER | FLATPAK_RUN_FLAG_NO_PROC,
                                     error))
     return FALSE;

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2018,7 +2018,7 @@ add_deps (FlatpakTransaction          *self,
     {
       /* If the runtime this app uses is already to be uninstalled, then this uninstall must happen before
          the runtime is uninstalled */
-      if (runtime_op && op->kind == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
+      if (runtime_op && runtime_op->kind == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
         run_operation_before (op, runtime_op, 1);
 
       return TRUE;

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2744,6 +2744,18 @@ resolve_ops (FlatpakTransaction *self,
       if (op->resolved)
         continue;
 
+      if (op->skip)
+        {
+          /* We're not yet resolved, but marked skip anyway, this can happen if during
+           * request_required_tokens() we were normalized away even though not fully resolved.
+           * For example we got the checksum but need to auth to get the commit, but the
+           * checksum we got was the version already installed.
+           */
+          g_assert (op->resolved_commit != NULL);
+          mark_op_resolved (op, op->resolved_commit, NULL, NULL, NULL);
+          continue;
+        }
+
       if (op->kind == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
         {
           /* We resolve to the deployed metadata, because we need it to uninstall related ops */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7381,23 +7381,23 @@ gboolean
 flatpak_dconf_path_is_similar (const char *path1,
                                const char *path2)
 {
-  int i, i1, i2;
+  int i1, i2;
   int num_components = -1;
 
-  for (i = 0; path1[i] != '\0'; i++)
+  for (i1 = i2 = 0; path1[i1] != '\0'; i1++, i2++)
     {
-      if (path2[i] == '\0')
+      if (path2[i2] == '\0')
         break;
 
-      if (tolower (path1[i]) == tolower (path2[i]))
+      if (tolower (path1[i1]) == tolower (path2[i2]))
         {
-          if (path1[i] == '/')
+          if (path1[i1] == '/')
             num_components++;
           continue;
         }
 
-      if ((path1[i] == '-' || path1[i] == '_') &&
-          (path2[i] == '-' || path2[i] == '_'))
+      if ((path1[i1] == '-' || path1[i1] == '_') &&
+          (path2[i2] == '-' || path2[i2] == '_'))
         continue;
 
       break;
@@ -7406,7 +7406,6 @@ flatpak_dconf_path_is_similar (const char *path1,
   /* Skip over any versioning if we have at least a TLD and
    * domain name, so 2 components */
   /* We need at least TLD, and domain name, so 2 components */
-  i1 = i2 = i;
   if (num_components >= 2)
     {
       while (isdigit (path1[i1]))

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7389,6 +7389,13 @@ flatpak_dconf_path_is_similar (const char *path1,
       if (path2[i2] == '\0')
         break;
 
+      if (isupper(path1[i1]) &&
+          (path2[i2] == '-' || path2[i2] == '_'))
+        i2++;
+
+      if (path2[i2] == '\0')
+        break;
+
       if (tolower (path1[i1]) == tolower (path2[i2]))
         {
           if (path1[i1] == '/')

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1527,11 +1527,10 @@ lookup_installation_for_path (GFile *path, GError **error)
   installation = g_hash_table_lookup (installation_cache, path);
   if (installation == NULL)
     {
-      g_autoptr(GError) error = NULL;
       g_autoptr(FlatpakDir) dir = NULL;
 
       dir = flatpak_dir_get_by_path (path);
-      installation = flatpak_installation_new_for_dir (dir, NULL, &error);
+      installation = flatpak_installation_new_for_dir (dir, NULL, error);
       if (installation == NULL)
         return NULL;
 

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1149,6 +1149,10 @@ test_dconf_paths (void)
     { "/org/gnome1/Rhythmbox/", "/org/gnome/rhythmbox", 0 },
     { "/org/gnome1/Rhythmbox", "/org/gnome/rhythmbox/", 0 },
     { "/org/gnome/Rhythmbox3plus/", "/org/gnome/rhythmbox/", 0 },
+    { "/org/gnome/SoundJuicer/", "/org/gnome/sound-juicer/", 1 },
+    { "/org/gnome/Sound-Juicer/", "/org/gnome/sound-juicer/", 1 },
+    { "/org/gnome/Soundjuicer/", "/org/gnome/sound-juicer/", 0 },
+    { "/org/gnome/Soundjuicer/", "/org/gnome/soundjuicer/", 1 },
   };
   int i;
 


### PR DESCRIPTION
Backport patches from upstream. This doesn't include the unused runtimes patches (which are pending in https://github.com/flatpak/flatpak/pull/3783) or the summary caching patches (which has ongoing work in https://github.com/flatpak/flatpak/pull/3781).

https://phabricator.endlessm.com/T29642