### PR TITLE
http: Return HOST_UNREACHABLE on error 500

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -462,6 +462,11 @@ load_uri_callback (GObject      *source_object,
           code = G_IO_ERROR_HOST_NOT_FOUND;
           break;
 
+        case SOUP_STATUS_INTERNAL_SERVER_ERROR:
+          /* The server did return something, but it was useless to us, so that’s basically equivalent to not returning */
+          code = G_IO_ERROR_HOST_UNREACHABLE;
+          break;
+
         case SOUP_STATUS_IO_ERROR:
 #if !GLIB_CHECK_VERSION(2, 44, 0)
           code = G_IO_ERROR_BROKEN_PIPE;


### PR DESCRIPTION
Sometimes a server might return a HTTP error 500 (this seems to happen
sometimes with Microsoft’s VSCode server, for example). Map this to
`G_IO_ERROR_HOST_UNREACHABLE` for now, which is a bit more specific than
returning `G_IO_ERROR_FAILED`, but without the hassle of introducing a
new public error domain which could give more detail.

In particular, this should allow gnome-software to show an error message
to the user for such failed downloads, rather than hiding the error and
logging the following:
```
not handling error failed for action download: While downloading http://packages.microsoft.com/repos/vscode/pool/main/c/code/code_1.45.1-1589445302_amd64.deb: Server returned status 500: Internal Server Error
```

Upstream: https://github.com/flatpak/flatpak/pull/3896
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

---

Trivial backport of https://github.com/flatpak/flatpak/pull/3896 (merged upstream already), for the purposes of T30217.

https://phabricator.endlessm.com/T30217