### PR TITLE
Make listing refs work for sideload repos

### DIFF
--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -164,7 +164,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          char *ref = key;
+          FlatpakCollectionRef *coll_ref = key;
+          char *ref = coll_ref->ref_name;
           char *partial_ref;
           const char *slash = strchr (ref, '/');
 
@@ -181,7 +182,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          const char *ref = key;
+          FlatpakCollectionRef *coll_ref = key;
+          const char *ref = coll_ref->ref_name;
           const char *checksum = value;
           g_auto(GStrv) parts = NULL;
 
@@ -235,7 +237,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
               strcmp (arches[0], parts[2]) != 0)
             {
               g_autofree char *alt_arch_ref = g_strconcat (parts[0], "/", parts[1], "/", arches[0], "/", parts[3], NULL);
-              if (g_hash_table_lookup (refs, alt_arch_ref))
+              g_autoptr(FlatpakCollectionRef) alt_arch_coll_ref = flatpak_collection_ref_new (coll_ref->collection_id, alt_arch_ref);
+              if (g_hash_table_lookup (refs, alt_arch_coll_ref))
                 continue;
             }
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -181,6 +181,21 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDeploy, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRelated, flatpak_related_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteState, flatpak_remote_state_unref)
 
+typedef struct
+{
+  char *collection_id;
+  char *ref_name;
+} FlatpakCollectionRef;
+
+FlatpakCollectionRef *    flatpak_collection_ref_new (const char *collection_id,
+                                                      const char *ref_name);
+void                      flatpak_collection_ref_free (FlatpakCollectionRef *ref);
+guint                     flatpak_collection_ref_hash (gconstpointer ref);
+gboolean                  flatpak_collection_ref_equal (gconstpointer ref1,
+                                                        gconstpointer ref2);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakCollectionRef, flatpak_collection_ref_free)
+
 typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NONE = 0,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE = 1 << 0,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11102,6 +11102,7 @@ static void
 populate_hash_table_from_refs_map (GHashTable         *ret_all_refs,
                                    GHashTable         *ref_timestamps,
                                    VarRefMapRef        ref_map,
+                                   const gchar        *collection_id,
                                    FlatpakRemoteState *state)
 {
   gsize len, i;
@@ -11114,8 +11115,8 @@ populate_hash_table_from_refs_map (GHashTable         *ret_all_refs,
       const guint8 *csum_bytes;
       gsize csum_len;
       VarRefInfoRef info;
-      char *ref_name_dup;
       guint64 *new_timestamp = NULL;
+      FlatpakCollectionRef *collection_ref;
 
       if (!flatpak_remote_state_allow_ref (state, ref_name))
         continue;
@@ -11141,11 +11142,57 @@ populate_hash_table_from_refs_map (GHashTable         *ret_all_refs,
           new_timestamp = g_memdup (&timestamp, sizeof (guint64));
         }
 
-      ref_name_dup = g_strdup (ref_name);
-      g_hash_table_replace (ret_all_refs, ref_name_dup, ostree_checksum_from_bytes (csum_bytes));
+      collection_ref = flatpak_collection_ref_new (collection_id, ref_name);
+      g_hash_table_replace (ret_all_refs, collection_ref, ostree_checksum_from_bytes (csum_bytes));
       if (new_timestamp)
-        g_hash_table_replace (ref_timestamps, ref_name_dup, new_timestamp);
+        g_hash_table_replace (ref_timestamps, g_strdup (ref_name), new_timestamp);
     }
+}
+
+/* The flatpak_collection_ref_* methods were copied from the
+ * ostree_collection_ref_* ones but allow a NULL collection ID */
+FlatpakCollectionRef *
+flatpak_collection_ref_new (const gchar *collection_id,
+                            const gchar *ref_name)
+{
+  g_autoptr(FlatpakCollectionRef) collection_ref = NULL;
+
+  collection_ref = g_new0 (FlatpakCollectionRef, 1);
+  collection_ref->collection_id = g_strdup (collection_id);
+  collection_ref->ref_name = g_strdup (ref_name);
+
+  return g_steal_pointer (&collection_ref);
+}
+
+void
+flatpak_collection_ref_free (FlatpakCollectionRef *ref)
+{
+  g_return_if_fail (ref != NULL);
+
+  g_free (ref->collection_id);
+  g_free (ref->ref_name);
+  g_free (ref);
+}
+
+guint
+flatpak_collection_ref_hash (gconstpointer ref)
+{
+  const FlatpakCollectionRef *_ref = ref;
+
+  if (_ref->collection_id != NULL)
+    return g_str_hash (_ref->collection_id) ^ g_str_hash (_ref->ref_name);
+  else
+    return g_str_hash (_ref->ref_name);
+}
+
+gboolean
+flatpak_collection_ref_equal (gconstpointer ref1,
+                              gconstpointer ref2)
+{
+  const FlatpakCollectionRef *_ref1 = ref1, *_ref2 = ref2;
+
+  return g_strcmp0 (_ref1->collection_id, _ref2->collection_id) == 0 &&
+         g_strcmp0 (_ref1->ref_name, _ref2->ref_name) == 0;
 }
 
 /* This tries to list all available remote refs but also tries to keep
@@ -11164,12 +11211,17 @@ flatpak_dir_list_all_remote_refs (FlatpakDir         *self,
   VarRefMapRef ref_map;
   VarVariantRef v;
 
-  /* This is  ref->commit */
-  ret_all_refs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  /* This is a mapping from FlatpakCollectionRef -> commit (a NULL collection
+   * ID implies the ref is from the remote @state) */
+  ret_all_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                        flatpak_collection_ref_equal,
+                                        (GDestroyNotify) flatpak_collection_ref_free,
+                                        g_free);
 
   if (state->summary != NULL)
     {
-      /* We're online, so report only the refs from the summary */
+      /* We're online (or the remote is on a local filesystem), so report only
+       * the refs from the summary */
 
       summary = var_summary_from_gvariant (state->summary);
 
@@ -11177,11 +11229,32 @@ flatpak_dir_list_all_remote_refs (FlatpakDir         *self,
 
       /* refs that match the main collection-id */
       ref_map = var_summary_get_ref_map (summary);
-      populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, state);
+      populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, state->collection_id, state);
+
+      /* The remote could be a sideload repo (made with create-usb) or a repo
+       * with a main collection ID set, and in either case we expect to find
+       * refs in the collection map, not the ref map above. */
+      if (var_metadata_lookup (exts, "ostree.summary.collection-map", NULL, &v))
+        {
+          VarCollectionMapRef map = var_collection_map_from_variant (v);
+          if (state->collection_id == NULL)
+            {
+              gsize len = var_collection_map_get_length (map);
+              for (gsize i = 0; i < len; i++)
+                {
+                  VarCollectionMapEntryRef entry = var_collection_map_get_at (map, i);
+                  const char *collection_id = var_collection_map_entry_get_key (entry);
+                  ref_map = var_collection_map_entry_get_value (entry);
+                  populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, collection_id, state);
+                }
+            }
+          else if (var_collection_map_lookup (map, state->collection_id, NULL, &ref_map))
+            populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, state->collection_id, state);
+        }
     }
   else if (state->collection_id)
     {
-      g_autoptr(GHashTable) ref_mtimes = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free); /* Keys owned by ret_all_refs */
+      g_autoptr(GHashTable) ref_mtimes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
       /* No main summary, add just all sideloded refs, with the latest version of each checksum */
 
@@ -11197,7 +11270,7 @@ flatpak_dir_list_all_remote_refs (FlatpakDir         *self,
               VarCollectionMapRef map = var_collection_map_from_variant (v);
 
               if (var_collection_map_lookup (map, state->collection_id, NULL, &ref_map))
-                populate_hash_table_from_refs_map (ret_all_refs, ref_mtimes, ref_map, state);
+                populate_hash_table_from_refs_map (ret_all_refs, ref_mtimes, ref_map, state->collection_id, state);
             }
         }
     }
@@ -11223,6 +11296,7 @@ find_matching_refs (GHashTable           *refs,
                     const char           *opt_default_branch,
                     const char           *opt_arch,
                     const char           *opt_default_arch,
+                    const char           *opt_collection_id,
                     FlatpakKinds          kinds,
                     FindMatchingRefsFlags flags,
                     GError              **error)
@@ -11258,13 +11332,13 @@ find_matching_refs (GHashTable           *refs,
   g_hash_table_iter_init (&hash_iter, refs);
   while (g_hash_table_iter_next (&hash_iter, &key, NULL))
     {
-      const char *ref_name = key;
       g_autofree char *ref = NULL;
       g_auto(GStrv) parts = NULL;
       gboolean is_app, is_runtime;
+      FlatpakCollectionRef *coll_ref = key;
 
       /* Unprefix any remote name if needed */
-      ostree_parse_refspec (ref_name, NULL, &ref, NULL);
+      ostree_parse_refspec (coll_ref->ref_name, NULL, &ref, NULL);
       if (ref == NULL)
         continue;
 
@@ -11300,6 +11374,9 @@ find_matching_refs (GHashTable           *refs,
       if (opt_branch != NULL && strcmp (opt_branch, parts[3]) != 0)
         continue;
 
+      if (opt_collection_id != NULL && g_strcmp0 (opt_collection_id, coll_ref->collection_id) != 0)
+        continue;
+
       if (opt_name != NULL && strcmp (opt_name, parts[1]) == 0)
         found_exact_name_match = TRUE;
 
@@ -11310,7 +11387,7 @@ find_matching_refs (GHashTable           *refs,
         found_default_branch_match = TRUE;
 
       if (flags & FIND_MATCHING_REFS_FLAGS_KEEP_REMOTE)
-        g_ptr_array_add (matched_refs, g_strdup (ref_name));
+        g_ptr_array_add (matched_refs, g_strdup (coll_ref->ref_name));
       else
         g_ptr_array_add (matched_refs, g_steal_pointer (&ref));
     }
@@ -11350,6 +11427,7 @@ find_matching_ref (GHashTable  *refs,
                    const char  *opt_branch,
                    const char  *opt_default_branch,
                    const char  *opt_arch,
+                   const char  *opt_collection_id,
                    FlatpakKinds kinds,
                    GError     **error)
 {
@@ -11372,6 +11450,7 @@ find_matching_ref (GHashTable  *refs,
                                          opt_default_branch,
                                          arches[i],
                                          NULL,
+                                         opt_collection_id,
                                          kinds,
                                          FIND_MATCHING_REFS_FLAGS_NONE,
                                          error);
@@ -11464,6 +11543,7 @@ flatpak_dir_find_remote_refs (FlatpakDir           *self,
                                      opt_default_branch,
                                      opt_arch,
                                      opt_default_arch,
+                                     state->collection_id,
                                      kinds,
                                      flags,
                                      error);
@@ -11487,6 +11567,7 @@ find_ref_for_refs_set (GHashTable   *refs,
                        const char   *opt_branch,
                        const char   *opt_default_branch,
                        const char   *opt_arch,
+                       const char   *opt_collection_id,
                        FlatpakKinds  kinds,
                        FlatpakKinds *out_kind,
                        GError      **error)
@@ -11497,6 +11578,7 @@ find_ref_for_refs_set (GHashTable   *refs,
                                              opt_branch,
                                              opt_default_branch,
                                              opt_arch,
+                                             opt_collection_id,
                                              kinds,
                                              &my_error);
   if (ref == NULL)
@@ -11566,6 +11648,7 @@ flatpak_dir_find_remote_ref (FlatpakDir   *self,
 
   remote_ref = find_ref_for_refs_set (remote_refs, name, opt_branch,
                                       opt_default_branch, opt_arch,
+                                      state->collection_id,
                                       kinds, out_kind, &my_error);
   if (!remote_ref)
     {
@@ -11585,6 +11668,37 @@ flatpak_dir_find_remote_ref (FlatpakDir   *self,
     }
 
   return g_steal_pointer (&remote_ref);
+}
+
+/* This will fill @out_all_refs with FlatpakCollectionRef:s which have a NULL
+ * collection ID, since the callers don't require that */
+static gboolean
+repo_list_dummy_collection_refs (OstreeRepo   *repo,
+                                 const char   *refspec_prefix,
+                                 GHashTable  **out_all_refs,
+                                 GCancellable *cancellable,
+                                 GError      **error)
+{
+  GHashTable *coll_refs = NULL;
+  g_autoptr(GHashTable) refs = NULL;
+
+  if (!ostree_repo_list_refs (repo, refspec_prefix, &refs, cancellable, error))
+    return FALSE;
+
+  coll_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                     flatpak_collection_ref_equal,
+                                     (GDestroyNotify) flatpak_collection_ref_free,
+                                     NULL);
+
+  GLNX_HASH_TABLE_FOREACH (refs, const char *, ref)
+    {
+      FlatpakCollectionRef *coll_ref = flatpak_collection_ref_new (NULL, ref);
+      g_hash_table_add (coll_refs, coll_ref);
+    }
+
+  *out_all_refs = coll_refs;
+
+  return TRUE;
 }
 
 char **
@@ -11608,9 +11722,8 @@ flatpak_dir_find_local_refs (FlatpakDir           *self,
   if (!flatpak_dir_ensure_repo (self, NULL, error))
     return NULL;
 
-  if (!ostree_repo_list_refs (self->repo,
-                              refspec_prefix,
-                              &local_refs, cancellable, error))
+  if (!repo_list_dummy_collection_refs (self->repo, refspec_prefix,
+                                        &local_refs, cancellable, error))
     return NULL;
 
   matched_refs = find_matching_refs (local_refs,
@@ -11619,6 +11732,7 @@ flatpak_dir_find_local_refs (FlatpakDir           *self,
                                      opt_default_branch,
                                      opt_arch,
                                      opt_default_arch,
+                                     NULL, /* shouldn't need collection */
                                      kinds,
                                      flags,
                                      &my_error);
@@ -11653,7 +11767,12 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
   if (!flatpak_dir_maybe_ensure_repo (self, NULL, error))
     return NULL;
 
-  local_refs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  /* Omit the collection ID part of these FlatpakCollectionRef:s as the callers
+   * don't need it */
+  local_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                      flatpak_collection_ref_equal,
+                                      (GDestroyNotify) flatpak_collection_ref_free,
+                                      NULL);
   if (kinds & FLATPAK_KINDS_APP)
     {
       g_auto(GStrv) app_refs = NULL;
@@ -11662,7 +11781,7 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
         return NULL;
 
       for (i = 0; app_refs[i] != NULL; i++)
-        g_hash_table_add (local_refs, g_strdup (app_refs[i]));
+        g_hash_table_add (local_refs, flatpak_collection_ref_new (NULL, app_refs[i]));
     }
   if (kinds & FLATPAK_KINDS_RUNTIME)
     {
@@ -11672,7 +11791,7 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
         return NULL;
 
       for (i = 0; runtime_refs[i] != NULL; i++)
-        g_hash_table_add (local_refs, g_strdup (runtime_refs[i]));
+        g_hash_table_add (local_refs, flatpak_collection_ref_new (NULL, runtime_refs[i]));
     }
 
   return g_steal_pointer (&local_refs);
@@ -11700,6 +11819,7 @@ flatpak_dir_find_installed_refs (FlatpakDir           *self,
                                      NULL, /* default branch */
                                      opt_arch,
                                      NULL, /* default arch */
+                                     NULL, /* shouldn't need collection */
                                      kinds,
                                      flags,
                                      error);
@@ -11728,7 +11848,7 @@ flatpak_dir_find_installed_ref (FlatpakDir   *self,
     return NULL;
 
   local_ref = find_matching_ref (local_refs, opt_name, opt_branch, NULL,
-                                 opt_arch, kinds, &my_error);
+                                 opt_arch, NULL, kinds, &my_error);
   if (local_ref == NULL)
     {
       if (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -11814,16 +11934,16 @@ flatpak_dir_cleanup_undeployed_refs (FlatpakDir   *self,
                                      GCancellable *cancellable,
                                      GError      **error)
 {
-  g_autoptr(GHashTable) local_refspecs = NULL;
+  g_autoptr(GHashTable) local_refs = NULL;
   g_autoptr(GPtrArray)  local_flatpak_refspecs = NULL;
   g_autoptr(GPtrArray) undeployed_refs = NULL;
   gsize i = 0;
 
-  if (!ostree_repo_list_refs (self->repo, NULL, &local_refspecs, cancellable, error))
+  if (!repo_list_dummy_collection_refs (self->repo, NULL, &local_refs, cancellable, error))
     return FALSE;
 
-  local_flatpak_refspecs = find_matching_refs (local_refspecs,
-                                               NULL, NULL, NULL, NULL, NULL,
+  local_flatpak_refspecs = find_matching_refs (local_refs,
+                                               NULL, NULL, NULL, NULL, NULL, NULL,
                                                FLATPAK_KINDS_APP |
                                                FLATPAK_KINDS_RUNTIME,
                                                FIND_MATCHING_REFS_FLAGS_KEEP_REMOTE,
@@ -12349,8 +12469,8 @@ flatpak_dir_remote_has_deploys (FlatpakDir *self,
   g_hash_table_iter_init (&hash_iter, refs);
   while (g_hash_table_iter_next (&hash_iter, &key, NULL))
     {
-      const char *ref = key;
-      g_autofree char *origin = flatpak_dir_get_origin (self, ref, NULL, NULL);
+      FlatpakCollectionRef *coll_ref = key;
+      g_autofree char *origin = flatpak_dir_get_origin (self, coll_ref->ref_name, NULL, NULL);
 
       if (strcmp (remote, origin) == 0)
         return TRUE;
@@ -13208,9 +13328,9 @@ remove_unless_in_hash (gpointer key,
                        gpointer user_data)
 {
   GHashTable *table = user_data;
-  const char *ref_name = key;
+  FlatpakCollectionRef *ref = key;
 
-  return !g_hash_table_contains (table, ref_name);
+  return !g_hash_table_contains (table, ref->ref_name);
 }
 
 gboolean

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -2408,11 +2408,13 @@ flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
   g_hash_table_iter_init (&iter, ht);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
-      const char *ref_name = key;
+      FlatpakCollectionRef *collection_ref = key;
       const gchar *ref_commit = value;
       FlatpakRemoteRef *ref;
 
-      ref = flatpak_remote_ref_new (ref_name, ref_commit, remote_or_uri, state->collection_id, state);
+      ref = flatpak_remote_ref_new (collection_ref->ref_name, ref_commit,
+                                    remote_or_uri, collection_ref->collection_id,
+                                    state);
 
       if (ref)
         g_ptr_array_add (refs, ref);
@@ -2485,6 +2487,7 @@ flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
   g_autoptr(FlatpakRemoteState) state = NULL;
   g_autofree char *ref = NULL;
   const char *checksum;
+  FlatpakCollectionRef coll_ref;
 
   if (branch == NULL)
     branch = "master";
@@ -2513,7 +2516,9 @@ flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
                                      branch,
                                      arch);
 
-  checksum = g_hash_table_lookup (ht, ref);
+  coll_ref.collection_id = state->collection_id;
+  coll_ref.ref_name = ref;
+  checksum = g_hash_table_lookup (ht, &coll_ref);
 
   if (checksum != NULL)
     return flatpak_remote_ref_new (ref, checksum, remote_name, state->collection_id, state);

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -511,6 +511,7 @@ handle_deploy (FlatpakSystemHelper   *object,
       g_autoptr(FlatpakOciImage) image_config = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
       g_autoptr(GHashTable) remote_refs = NULL;
+      FlatpakCollectionRef collection_ref;
       g_autofree char *checksum = NULL;
       const char *verified_digest;
       g_autofree char *upstream_url = NULL;
@@ -589,7 +590,10 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      verified_digest = g_hash_table_lookup (remote_refs, arg_ref);
+      collection_ref.collection_id = state->collection_id;
+      collection_ref.ref_name = (char *) arg_ref;
+
+      verified_digest = g_hash_table_lookup (remote_refs, &collection_ref);
       if (!verified_digest)
         {
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,


### PR DESCRIPTION
This commit makes
flatpak_installation_list_remote_refs_sync() work for local URIs
pointing at sideload repos, e.g.
"file:///media/mwleeds/flatpaks/.ostree/repo" where a command "flatpak
create-usb /media/mwleeds/flatpaks ..." was previously run. This is
important because the Endless fork of gnome-software uses that API to
list apps on a USB drive. The API worked before Flatpak 1.7.1 so making
it work again basically involves reverting parts of
336a127f5515f69c7d5c6aa7943076035c59bf84.

This commit also makes the remote-ls command work for file:// URIs to
sideload repos, which is useful behavior for debugging, and is also the
behavior mentioned in this blog post:
https://blogs.gnome.org/mclasen/2018/08/26/about-flatpak-installations/

https://phabricator.endlessm.com/T30368