### PR TITLE
profile: Don't add current directory to PATH

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -46,5 +46,5 @@ if command -v flatpak > /dev/null; then
     )
 
     export PATH
-    PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games}:${new_dirs:+${new_dirs}}"
+    PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games}${new_dirs:+:${new_dirs}}"
 fi


### PR DESCRIPTION
If `new_dirs` is empty because the flatpak exported `bin` directories
are already in `PATH`, then `PATH` will contain a trailing `:`. An empty
element in `PATH` means that the current directory should be searched.
While some users may want this behavior, it was not the intention of the
change here to prefix `PATH` with the flatpak exported `bin`
directories. The change here is to only prefix `:` when `new_dirs` is
not empty. This is similar to the `XDG_DATA_DIRS` mangling which only
suffixes `:` if `new_dirs` is not empty.

This can be squashed into dacf0a884ea9d52e763d2f5cb1d720c6fdf7be2f on
the next rebase.

I was surprised to find that programs were being searched for in the current directory and found this to be the culprit. I don't know if the commit title should be in `fixup!` format or not for future rebasing.