### PR TITLE
T30972 Backport fix for parental controls in gnome-initial-setup (eos3.9)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -172,6 +172,9 @@ flatpak.env: env.d/flatpak.env.in
 		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
 		$< > $@
 
+systemenvgendir = $(systemdsystemenvgendir)
+systemenvgen_SCRIPTS = env.d/60-flatpak
+
 userenvgendir = $(systemduserenvgendir)
 userenvgen_SCRIPTS = env.d/60-flatpak
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -172,8 +172,8 @@ flatpak.env: env.d/flatpak.env.in
 		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
 		$< > $@
 
-envgendir = $(systemduserenvgendir)
-envgen_SCRIPTS = env.d/60-flatpak
+userenvgendir = $(systemduserenvgendir)
+userenvgen_SCRIPTS = env.d/60-flatpak
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = flatpak.pc

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,15 @@ AC_ARG_WITH([systemdsystemunitdir],
     [with_systemdsystemunitdir='${prefix}/lib/systemd/system'])
 AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 
+AC_ARG_WITH([systemdsystemenvgendir],
+            [AS_HELP_STRING([--with-systemdsystemenvgendir=DIR],
+                            [Directory for systemd system environment generators (default=PREFIX/lib/systemd/system-environment-generators)])],
+    [],
+    dnl This is deliberately not ${libdir}: systemd units always go in
+    dnl .../lib, never .../lib64 or .../lib/x86_64-linux-gnu
+    [with_systemdsystemenvgendir='${prefix}/lib/systemd/system-environment-generators'])
+AC_SUBST([systemdsystemenvgendir], [$with_systemdsystemenvgendir])
+
 AC_ARG_WITH([systemduserenvgendir],
             [AS_HELP_STRING([--with-systemduserenvgendir=DIR],
                             [Directory for systemd user environment generators (default=PREFIX/lib/systemd/user-environment-generators)])],

--- a/env.d/60-flatpak
+++ b/env.d/60-flatpak
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Only include the ~/.local/share/flatpak path if this is being run as a *user*
+# environment generator. If run as a *system* environment generator, only
+# include the system installations.
+if [[ "$(basename $(dirname $0))" == "user-environment-generators" ]]; then
+    include_home=1
+else
+    include_home=0
+fi
+
 new_dirs=
 while read -r install_path
 do
@@ -9,7 +18,7 @@ do
         *":$share_path/:"*) :;;
         *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
     esac
-done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak  --installations)
+done < <(if [[ $include_home == 1 ]]; then echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; fi; flatpak  --installations)
 
 XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"


### PR DESCRIPTION
Cherry-pick of #243 to `eos3.9`. No conflicts.

https://phabricator.endlessm.com/T30972