### PR TITLE
debian: Install system environment generator (eos3.9)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flatpak (1.8.2-1endless2) master; urgency=medium
+
+  * Install system environment generator (T30972)
+
+ -- Philip Withnall <pwithnall@endlessos.org>  Wed, 28 Oct 2020 17:17:00 +0000
+
 flatpak (1.8.2-1endless1) master; urgency=medium
 
   * New upstream stable release

--- a/debian/flatpak.install
+++ b/debian/flatpak.install
@@ -5,6 +5,7 @@ etc/X11/Xsession.d
 etc/profile.d/
 lib/systemd/system/flatpak-system-helper.service
 usr/bin/flatpak
+usr/lib/systemd/system-environment-generators
 usr/lib/systemd/user-environment-generators
 usr/lib/systemd/user/flatpak-oci-authenticator.service
 usr/lib/systemd/user/flatpak-portal.service


### PR DESCRIPTION
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T30972

---

Cherry-pick of #245 to `debian-eos3.9`. No conflicts.