### PR TITLE
Backports from 1.8.3

### DIFF
--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -370,6 +370,8 @@ flatpak_progress_update_extra_data (FlatpakProgress *self,
 
   self->transferred_extra_data_bytes = self->extra_data_previous_dl + downloaded_bytes;
   update_status_progress_and_estimating (self);
+
+  self->callback (self->status, self->progress, self->estimating, self->user_data);
 }
 
 void

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1872,11 +1872,13 @@ flatpak_transaction_add_op (FlatpakTransaction             *self,
                             const char                    **previous_ids,
                             const char                     *commit,
                             GFile                          *bundle,
-                            FlatpakTransactionOperationType kind)
+                            FlatpakTransactionOperationType kind,
+                            GError                        **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
   FlatpakTransactionOperation *op;
   g_autofree char *subpaths_str = NULL;
+  g_auto(GStrv) ref_parts = NULL;
 
   subpaths_str = subpaths_to_string (subpaths);
   g_debug ("Transaction: %s %s:%s%s%s%s",
@@ -1884,6 +1886,11 @@ flatpak_transaction_add_op (FlatpakTransaction             *self,
            commit != NULL ? "@" : "",
            commit != NULL ? commit : "",
            subpaths_str);
+
+  /* Sanity check the ref format. */
+  ref_parts = flatpak_decompose_ref (ref, error);
+  if (ref_parts == NULL)
+    return NULL;
 
   op = flatpak_transaction_get_last_op_for_ref (self, ref);
   /* If previous_ids is given, then this is a rebase operation. */
@@ -1999,7 +2006,11 @@ add_related (FlatpakTransaction          *self,
 
           related_op = flatpak_transaction_add_op (self, op->remote, rel->ref,
                                                    NULL, NULL, NULL, NULL,
-                                                   FLATPAK_TRANSACTION_OPERATION_UNINSTALL);
+                                                   FLATPAK_TRANSACTION_OPERATION_UNINSTALL,
+                                                   error);
+          if (related_op == NULL)
+            return FALSE;
+
           related_op->non_fatal = TRUE;
           related_op->fail_if_op_fails = op;
           flatpak_transaction_operation_add_related_to_op (related_op, op);
@@ -2019,7 +2030,11 @@ add_related (FlatpakTransaction          *self,
           related_op = flatpak_transaction_add_op (self, op->remote, rel->ref,
                                                    (const char **) rel->subpaths,
                                                    NULL, NULL, NULL,
-                                                   FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);
+                                                   FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE,
+                                                   error);
+          if (related_op == NULL)
+            return FALSE;
+
           related_op->non_fatal = TRUE;
           related_op->fail_if_op_fails = op;
           flatpak_transaction_operation_add_related_to_op (related_op, op);
@@ -2141,7 +2156,9 @@ add_deps (FlatpakTransaction          *self,
             return FALSE;
 
           runtime_op = flatpak_transaction_add_op (self, runtime_remote, full_runtime_ref, NULL, NULL, NULL, NULL,
-                                                   FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);
+                                                   FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE, error);
+          if (runtime_op == NULL)
+            return FALSE;
         }
       else
         {
@@ -2150,7 +2167,9 @@ add_deps (FlatpakTransaction          *self,
             {
               g_debug ("Updating dependent runtime %s", full_runtime_ref);
               runtime_op = flatpak_transaction_add_op (self, runtime_remote, full_runtime_ref, NULL, NULL, NULL, NULL,
-                                                       FLATPAK_TRANSACTION_OPERATION_UPDATE);
+                                                       FLATPAK_TRANSACTION_OPERATION_UPDATE, error);
+              if (runtime_op == NULL)
+                return FALSE;
               runtime_op->non_fatal = TRUE;
             }
         }
@@ -2287,7 +2306,9 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
         return FALSE;
     }
 
-  op = flatpak_transaction_add_op (self, remote, ref, subpaths, previous_ids, commit, bundle, kind);
+  op = flatpak_transaction_add_op (self, remote, ref, subpaths, previous_ids, commit, bundle, kind, error);
+  if (op == NULL)
+    return FALSE;
 
   if (external_metadata)
     op->external_metadata = g_bytes_new (external_metadata, strlen (external_metadata) + 1);
@@ -4298,7 +4319,10 @@ add_uninstall_unused_ops (FlatpakTransaction  *self,
           /* These get added last and have no dependencies, so will run last */
           uninstall_op = flatpak_transaction_add_op (self, origin, unused_ref,
                                                      NULL, NULL, NULL, NULL,
-                                                     FLATPAK_TRANSACTION_OPERATION_UNINSTALL);
+                                                     FLATPAK_TRANSACTION_OPERATION_UNINSTALL,
+                                                     error);
+          if (uninstall_op == NULL)
+            return FALSE;
           run_operation_last (uninstall_op);
         }
     }

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3391,7 +3391,7 @@ request_tokens_for_remote (FlatpakTransaction *self,
       if (g_variant_lookup (results, "error-code", "i", &error_code) && error_code != -1)
         {
           if (error_message)
-            flatpak_fail_error (error, error_code, _("Failed to get tokens for ref: %s"), error_message);
+            return flatpak_fail_error (error, error_code, _("Failed to get tokens for ref: %s"), error_message);
           else
             return flatpak_fail_error (error, error_code, _("Failed to get tokens for ref"));
         }

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -297,7 +297,7 @@ make_runtime () {
         ostree --repo=repos/${REPONAME} init --mode=archive-z2 ${collection_args}
     fi
 
-    flatpak build-commit-from --disable-fsync --src-repo=${RUNTIME_REPO} --force ${GPGARGS} repos/${REPONAME}  ${RUNTIME_REF}
+    flatpak build-commit-from --disable-fsync --no-update-summary --src-repo=${RUNTIME_REPO} --force ${GPGARGS} repos/${REPONAME}  ${RUNTIME_REF}
 }
 
 httpd () {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -394,6 +394,10 @@ update_repo () {
         collection_args=
     fi
 
+    if test -f repos/${REPONAME}/summary; then
+        sleep 1 # ensure we get a new timestamp on the summary files
+    fi
+
     ${FLATPAK} build-update-repo ${collection_args} ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME}
 }
 

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -137,7 +137,7 @@ ln -s -t ${DIR}/files/share/locale ../../share/runtime/locale/fr/share/fr
 
 flatpak build-finish ${BUILD_FINISH_ARGS-} --command=hello.sh ${DIR}
 mkdir -p repos
-flatpak build-export --disable-sandbox ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
+flatpak build-export --no-update-summary --disable-sandbox ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
 rm -rf ${DIR}
 
 # build a locale extension
@@ -168,7 +168,5 @@ msgfmt --output-file ${DIR}/files/fr/share/fr/LC_MESSAGES/helloworld.mo fr.po
 
 flatpak build-finish ${DIR}
 mkdir -p repos
-flatpak build-export --runtime ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
+flatpak build-export --no-update-summary --runtime ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
 rm -rf ${DIR}
-
-

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -97,5 +97,5 @@ else
 fi
 
 mkdir -p repos
-flatpak build-export ${collection_args} --disable-sandbox --runtime ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
+flatpak build-export ${collection_args} --no-update-summary --disable-sandbox --runtime ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
 rm -rf ${DIR}

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -113,7 +113,8 @@ make_updated_app test "" master UPDATE3
 ${FLATPAK} ${U} update -y org.test.Hello
 
 # Use build-commit-from to add it to a new version
-$FLATPAK build-commit-from  ${FL_GPGARGS} --token-type=2 --disable-fsync --src-ref=app/org.test.Hello/$ARCH/master repos/test app/org.test.Hello/$ARCH/copy
+$FLATPAK build-commit-from  --no-update-summary ${FL_GPGARGS} --token-type=2 --disable-fsync --src-ref=app/org.test.Hello/$ARCH/master repos/test app/org.test.Hello/$ARCH/copy
+update_repo
 mark_need_token app/org.test.Hello/$ARCH/copy the-secret
 
 # Install with wrong token

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -40,7 +40,8 @@ EOF
     touch ${DIR}/usr/exists
     touch ${DIR}/usr/extension-$ID:$VERSION
 
-    ${FLATPAK} build-export --runtime ${GPGARGS-} repos/test ${DIR} ${VERSION}
+    ${FLATPAK} build-export --no-update-summary --runtime ${GPGARGS-} repos/test ${DIR} ${VERSION}
+    update_repo
     rm -rf ${DIR}
 
     ${FLATPAK} --user install -y test-repo $ID $VERSION
@@ -101,8 +102,8 @@ $(dirname $0)/make-test-app.sh repos/test "" master "" > /dev/null
 # Modify platform metadata
 ostree checkout -U --repo=repos/test runtime/org.test.Platform/${ARCH}/master platform
 add_extensions platform
-${FLATPAK} build-export --disable-sandbox repos/test platform --files=files master
-${FLATPAK} build-update-repo repos/test
+${FLATPAK} build-export --no-update-summary --disable-sandbox repos/test platform --files=files master
+update_repo
 
 ${FLATPAK} remote-add --user --no-gpg-verify test-repo repos/test
 ${FLATPAK} --user install -y test-repo org.test.Platform master
@@ -155,8 +156,8 @@ ok "runtime extensions"
 # Modify app metadata
 ostree checkout -U --repo=repos/test app/org.test.Hello/${ARCH}/master hello
 add_extensions hello
-${FLATPAK} build-export --disable-sandbox repos/test hello master
-${FLATPAK} build-update-repo repos/test
+${FLATPAK} build-export --no-update-summary --disable-sandbox repos/test hello master
+update_repo
 
 ${FLATPAK} --user update -y org.test.Hello master
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -326,7 +326,7 @@ else
 fi
 
 ostree init --repo=repos/test-copy --mode=archive-z2 ${copy_collection_args}
-${FLATPAK} build-commit-from --end-of-life=Reason1 --src-repo=repos/test repos/test-copy app/org.test.Hello/$ARCH/master
+${FLATPAK} build-commit-from --no-update-summary --end-of-life=Reason1 --src-repo=repos/test repos/test-copy app/org.test.Hello/$ARCH/master
 update_repo test-copy ${COPY_COLLECTION_ID}
 
 # Ensure we have no eol app in appdata
@@ -387,7 +387,7 @@ else
 fi
 
 ostree init --repo=repos/test-rebase --mode=archive-z2 ${rebase_collection_args}
-${FLATPAK} build-commit-from --src-repo=repos/test ${FL_GPGARGS} repos/test-rebase app/org.test.Hello/$ARCH/master runtime/org.test.Hello.Locale/$ARCH/master
+${FLATPAK} build-commit-from --no-update-summary --src-repo=repos/test ${FL_GPGARGS} repos/test-rebase app/org.test.Hello/$ARCH/master runtime/org.test.Hello.Locale/$ARCH/master
 update_repo test-rebase ${REBASE_COLLECTION_ID}
 
 flatpak remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR}/pubring.gpg test-rebase "http://127.0.0.1:${port}/test-rebase"
@@ -399,8 +399,9 @@ ${CMD_PREFIX} flatpak run --command=bash org.test.Hello -c 'echo foo > $XDG_DATA
 assert_has_dir $HOME/.var/app/org.test.Hello
 assert_has_file $HOME/.var/app/org.test.Hello/data/a-file
 
-${FLATPAK} build-commit-from --end-of-life-rebase=org.test.Hello=org.test.NewHello --src-repo=repos/test ${FL_GPGARGS} repos/test-rebase app/org.test.Hello/$ARCH/master runtime/org.test.Hello.Locale/$ARCH/master
+${FLATPAK} build-commit-from --no-update-summary --end-of-life-rebase=org.test.Hello=org.test.NewHello --src-repo=repos/test ${FL_GPGARGS} repos/test-rebase app/org.test.Hello/$ARCH/master runtime/org.test.Hello.Locale/$ARCH/master
 GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test-rebase org.test.NewHello master "${REBASE_COLLECTION_ID}" "NEW" > /dev/null
+update_repo test-rebase
 
 ${FLATPAK} ${U} update -y org.test.Hello
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -510,12 +510,21 @@ update_repo test-gpg3 org.test.Collection.test
 ${FLATPAK} ${U} install -y test-repo org.test.Hello
 assert_file_has_content $FL_DIR/app/org.test.Hello/$ARCH/master/active/files/bin/hello.sh UPDATED
 
+# Switch back to the old url to unconfuse other tests
+UPDATE_REPO_ARGS="--redirect-url=" update_repo
+${FLATPAK} ${U} remote-modify --url="http://127.0.0.1:${port}/test" test-repo
+
+# Also remove app so we can install the older one from the previous repo
+${FLATPAK} ${U} uninstall -y org.test.Hello
+
 ok "redirect url and gpg key"
+
+${FLATPAK} ${U} install -y -v test-repo org.test.Hello
 
 # Test https://github.com/flatpak/flatpak/issues/3222
 mkdir -p $FL_DIR/repo/refs/mirrors/org.test.Collection.test/app/org.test.Hello/$ARCH/
 cp $FL_DIR/repo/refs/remotes/test-repo/app/org.test.Hello/$ARCH/master $FL_DIR/repo/refs/mirrors/org.test.Collection.test/app/org.test.Hello/$ARCH/
-make_updated_app test-gpg3 org.test.Collection.test master UPDATE2
+make_updated_app test org.test.Collection.test master UPDATE2
 ${FLATPAK} ${U} update -y org.test.Hello
 assert_not_has_file $FL_DIR/repo/refs/mirrors/org.test.Collection.test/app/org.test.Hello/$ARCH/master
 assert_has_file $FL_DIR/repo/refs/remotes/test-repo/app/org.test.Hello/$ARCH/master

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -305,7 +305,7 @@ echo "d" > ${DIR}/files/d/data
 echo "nope" > ${DIR}/files/nope
 
 ${FLATPAK} build-finish --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 update_repo
 
 ${FLATPAK} ${U} install -y test-repo org.test.Split --subpath=/a --subpath=/b --subpath=/nosuchdir stable
@@ -331,7 +331,7 @@ mkdir -p ${DIR}/files/f
 echo "f" > ${DIR}/files/f/data
 rm -rf  ${DIR}/files/b
 
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 update_repo
 
 ${FLATPAK} ${U} update -y --subpath=/a --subpath=/b --subpath=/e --subpath=/nosuchdir org.test.Split
@@ -351,7 +351,7 @@ assert_has_file $FL_DIR/app/org.test.Split/$ARCH/stable/active/files/e/data
 assert_not_has_file $FL_DIR/app/org.test.Split/$ARCH/stable/active/files/f
 assert_not_has_file $FL_DIR/app/org.test.Split/$ARCH/stable/active/files/nope
 
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 update_repo
 
 # Test reusing the old subpath list
@@ -379,15 +379,15 @@ VERSION=`cat "$test_builddir/package_version.txt"`
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.CurrentVersion org.test.Platform org.test.Platform stable
 ${FLATPAK} build-finish --require-version=${VERSION} --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.OldVersion org.test.Platform org.test.Platform stable
 ${FLATPAK} build-finish --require-version=0.6.10 --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.NewVersion org.test.Platform org.test.Platform stable
 ${FLATPAK} build-finish --require-version=1${VERSION} --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 
 update_repo
 
@@ -398,14 +398,16 @@ ${FLATPAK} ${U} install -y test-repo org.test.CurrentVersion stable
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.OldVersion org.test.Platform org.test.Platform stable
 ${FLATPAK} build-finish --require-version=99.0.0 --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export  --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
+update_repo
 
 (! ${FLATPAK} ${U} update -y org.test.OldVersion)
 
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.OldVersion org.test.Platform org.test.Platform stable
 ${FLATPAK} build-finish --require-version=0.1.1 --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export  --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
+update_repo
 
 ${FLATPAK} ${U} update -y org.test.OldVersion
 
@@ -417,12 +419,13 @@ DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.CurrentVersion org.test.Platform org.test.Platform stable
 touch ${DIR}/files/updated
 ${FLATPAK} build-finish --require-version=99.0.0 --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
 DIR=`mktemp -d`
 ${FLATPAK} build-init ${DIR} org.test.OldVersion org.test.Platform org.test.Platform stable
 touch ${DIR}/files/updated
 ${FLATPAK} build-finish --require-version=${VERSION} --command=hello.sh ${DIR}
-${FLATPAK} build-export ${FL_GPGARGS} repos/test ${DIR} stable
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} repos/test ${DIR} stable
+update_repo
 
 if ${FLATPAK} ${U} update -y &> err_version.txt; then
     assert_not_reached "Should not have been able to update due to version"
@@ -440,7 +443,7 @@ mkdir -p app/files/a-dir
 chmod a+rwx app/files/a-dir
 flatpak build-finish --command=hello.sh app
 # Note: not --canonical-permissions
-${FLATPAK} build-export -vv --disable-sandbox --files=files repos/test app stable
+${FLATPAK} build-export -vv  --no-update-summary --disable-sandbox --files=files repos/test app stable
 ostree --repo=repos/test commit  --keep-metadata=xa.metadata --owner-uid=0 --owner-gid=0  --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Writable/$ARCH/stable app
 update_repo
 
@@ -460,7 +463,7 @@ touch app/files/exe
 chmod u+s app/files/exe
 flatpak build-finish --command=hello.sh app
 # Note: not --canonical-permissions
-${FLATPAK} build-export -vv --disable-sandbox --files=files repos/test app stable
+${FLATPAK} build-export -vv  --no-update-summary --disable-sandbox --files=files repos/test app stable
 ostree -v --repo=repos/test commit --keep-metadata=xa.metadata --owner-uid=0 --owner-gid=0 --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Setuid/$ARCH/stable app
 update_repo
 
@@ -476,7 +479,7 @@ flatpak build-init app org.test.App org.test.Platform org.test.Platform stable
 mkdir -p app/files/
 touch app/files/exe
 flatpak build-finish --command=hello.sh --sdk=org.test.Sdk app
-${FLATPAK} build-export ${FL_GPGARGS} repos/test app stable
+${FLATPAK} build-export  --no-update-summary ${FL_GPGARGS} repos/test app stable
 update_repo
 
 ${FLATPAK} ${U} install -y test-repo org.test.App

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -38,7 +38,7 @@ ${FLATPAK} build-init ${DIR} org.test.App org.test.Platform org.test.Platform
 mkdir -p ${DIR}/files/a
 echo "a" > ${DIR}/files/a/data
 ${FLATPAK} build-finish ${DIR} --socket=x11 --share=network --command=true
-${FLATPAK} build-export ${FL_GPGARGS} --update-appstream repos/test ${DIR} master
+${FLATPAK} build-export --no-update-summary ${FL_GPGARGS} --update-appstream repos/test ${DIR} master
 update_repo
 
 ${FLATPAK} ${U} install -y test-repo org.test.App master
@@ -53,7 +53,7 @@ assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id='
 # but don’t mark the collection ID as to be deployed yet. Ensure it doesn’t
 # appear in the client’s configuration.
 echo -e "[core]\ncollection-id=org.test.Collection" >> repos/test/config
-${FLATPAK} build-export ${FL_GPGARGS} --update-appstream repos/test --collection-id org.test.Collection ${DIR} master
+${FLATPAK} build-export --no-update-summary  ${FL_GPGARGS} --update-appstream repos/test --collection-id org.test.Collection ${DIR} master
 UPDATE_REPO_ARGS="--collection-id=org.test.Collection" update_repo
 
 ${FLATPAK} ${U} update -y org.test.App master


### PR DESCRIPTION
These are cherry-picks from the upstream 1.8.3 release.

The one "tests: Avoid unnecessarily recreating the summary file" is not strictly necessary since we don't have the latest ostree (which itself hasn't been released) but seems useful in case we update or a developer builds against it.

The changes made to the cherry-picks were minor, and noted in the commit messages.

https://phabricator.endlessm.com/T31110