### PR TITLE
Don't auto-install sources for extensions

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2720,6 +2720,8 @@ flatpak_summary_match_subrefs (GVariant   *summary_v,
           VarRefMapEntryRef entry = var_ref_map_get_at (ref_map, i);
           const char *cur;
           const char *id_start;
+          const char *id_suffix;
+          const char *id_end;
 
           cur = var_ref_map_entry_get_ref (entry);
 
@@ -2734,9 +2736,19 @@ flatpak_summary_match_subrefs (GVariant   *summary_v,
           id_start = strchr (cur, '/');
           if (id_start == NULL)
             continue;
+          id_start += 1;
+
+          id_end = strchr (id_start, '/');
+          if (id_end == NULL)
+            continue;
 
           /* But only prefix of id */
-          if (!g_str_has_prefix (id_start + 1, parts_prefix))
+          if (!g_str_has_prefix (id_start, parts_prefix))
+            continue;
+
+          /* And no dots (we want to install prefix.$ID, but not prefix.$ID.Sources) */
+          id_suffix = id_start + strlen (parts_prefix);
+          if (memchr (id_suffix, '.', id_end - id_suffix) != NULL)
             continue;
 
           g_ptr_array_add (res, g_strdup (cur));


### PR DESCRIPTION
There was a bug in the extension point matcher which made it
install `org.gnome.Totem.Videosite.YouTubeDl.Sources` (in addition to
`org.gnome.Totem.Videosite.YouTubeDl`) for the `org.gnome.Totem.Videosite`
extension.

We just need to make sure we only match the extension prefix if there
is a single element in the extension name following the extension
name (i.e. '.YouTubeDl', not '.YouTubeDl.Sources').

This fixes https://github.com/flatpak/flatpak/issues/3973

(cherry picked from commit f650c303e3edff8127ca24fb631b09fcebb36084)

https://phabricator.endlessm.com/T31110