### PR TITLE
flatpak-installation: Add default dep sources to list installed refs

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1069,6 +1069,9 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
   if (transaction == NULL)
     return NULL;
 
+  /* CLI transactions set this. */
+  flatpak_transaction_add_default_dependency_sources (transaction);
+
   installed_refs_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   for (guint i = 0; i < installed_refs->len; i++)


### PR DESCRIPTION
It seems that all `FlatpakTransaction`s add the default dep sources, so
the internal transaction used to list installed refs for updates should
do the same.

This fixes a bug where
`flatpak_installation_list_installed_refs_for_update()` would return an
error saying “The application x requires the runtime y which was not
found” if the app was installed in the user repo, the runtime was
installed in the system repo, and no remote was configured (or one was
configured `xa.noenumerate=true`) in the user repo to provide the
runtime. If a remote was configured, the error wouldn’t be returned, but
the app would be spuriously listed for an update as its runtime couldn’t
be found.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
Upstream: https://github.com/flatpak/flatpak/pull/3994
https://phabricator.endlessm.com/T30233

---

Trivial cherry-pick to `eos3.9`.