### PR TITLE
T31249 Backport missing deploy file fix from upstream (eos3.9)

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9522,6 +9522,7 @@ flatpak_dir_update (FlatpakDir                           *self,
 {
   g_autoptr(GBytes) deploy_data = NULL;
   const char **subpaths = NULL;
+  const char *empty_subpaths[] = {NULL};
   g_autofree char *url = NULL;
   FlatpakPullFlags flatpak_flags;
   g_autofree const char **old_subpaths = NULL;
@@ -9544,8 +9545,10 @@ flatpak_dir_update (FlatpakDir                           *self,
 
   if (opt_subpaths)
     subpaths = opt_subpaths;
-  else
+  else if (old_subpaths)
     subpaths = old_subpaths;
+  else
+    subpaths = empty_subpaths;
 
   if (!ostree_repo_remote_get_url (self->repo, state->remote_name, &url, error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1910,6 +1910,8 @@ flatpak_dir_system_helper_call_deploy (FlatpakDir         *self,
 {
   const char *empty[] = { NULL };
 
+  if (arg_subpaths == NULL)
+    arg_subpaths = empty;
   if (arg_previous_ids == NULL)
     arg_previous_ids = empty;
 


### PR DESCRIPTION
Trivial backport of #258 to `eos3.9`.

https://phabricator.endlessm.com/T31249