### PR TITLE
flatpak-dir: Make parental controls polkit query interactive iff dir is

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7724,6 +7724,8 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   g_autoptr(AutoPolkitAuthorizationResult) result = NULL;
   gboolean authorized;
   gboolean repo_installation_allowed, app_is_appropriate;
+  PolkitCheckAuthorizationFlags polkit_flags;
+  MctGetAppFilterFlags manager_flags;
 
   /* The ostree-metadata and appstream/ branches should not have any parental
    * controls restrictions. Similarly, for the moment, there is no point in
@@ -7776,8 +7778,11 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
     }
 
   manager = mct_manager_new (dbus_connection);
+  manager_flags = MCT_GET_APP_FILTER_FLAGS_NONE;
+  if (!flatpak_dir_get_no_interaction (self))
+    manager_flags |= MCT_GET_APP_FILTER_FLAGS_INTERACTIVE;
   app_filter = mct_manager_get_app_filter (manager, subject_uid,
-                                           MCT_GET_APP_FILTER_FLAGS_INTERACTIVE,
+                                           manager_flags,
                                            cancellable, &local_error);
   if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
     {
@@ -7815,10 +7820,13 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   if (authority == NULL)
     return FALSE;
 
+  polkit_flags = POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE;
+  if (!flatpak_dir_get_no_interaction (self))
+    polkit_flags |= POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
   result = polkit_authority_check_authorization_sync (authority, subject,
                                                       "org.freedesktop.Flatpak.override-parental-controls",
                                                       NULL,
-                                                      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+                                                      polkit_flags,
                                                       cancellable, error);
   if (result == NULL)
     return FALSE;


### PR DESCRIPTION
Previously, the polkit query was always interactive, even if the
`FlatpakDir` was operating in non-interactive mode (for example, for a
background update in gnome-software). Make the interactivity match the
interactivity of the `FlatpakDir`.

Do the same for the `mct_manager_get_app_filter()` call, although this
is less important since under normal conditions it will never prompt the
user.

This should hopefully stop polkit prompts appearing periodically when
background updates are being done while logged in as a non-privileged
user with parental controls set to prevent application installation.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

---

Trivial backport of https://github.com/flatpak/flatpak/pull/4178