### PR TITLE
tests: web-server: fix an issue with the web server cache

### DIFF
--- a/tests/web-server.py
+++ b/tests/web-server.py
@@ -37,6 +37,7 @@ class RequestHandler(http_server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.handle_tokens():
             return None
+        self.headers.__delitem__("If-Modified-Since")
         return super().do_GET()
 
 def run(dir):


### PR DESCRIPTION
On a decently fast system, some files may be fetched, modified and then
fetched again within the same second. In that case, the web server
replies with a code 304 ("Not modified") to the 2nd query, causing some
tests to fail.

This commit forces the web server to ignore `If-Modified-Since` HTTP
headers, effectively disabling caching in order to mitigate the problem.

(cherry picked from commit 6996580bb825b091db9c9bd60cbc5aeff557e7cf)

Currently the flatpak tests are failing in semi-random ways and this fixes the
tests locally for me.

https://phabricator.endlessm.com/T31593