### PR TITLE
system-helper: Set interactivity on the FlatpakDir from D-Bus call flags

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -224,6 +224,7 @@ schedule_idle_callback (void)
 static FlatpakDir *
 dir_get_system (const char *installation,
                 pid_t       source_pid,
+                gboolean    no_interaction,
                 GError    **error)
 {
   FlatpakDir *system = NULL;
@@ -239,6 +240,7 @@ dir_get_system (const char *installation,
 
   flatpak_dir_set_source_pid (system, source_pid);
   flatpak_dir_set_no_system_helper (system, TRUE);
+  flatpak_dir_set_no_interaction (system, no_interaction);
 
   return system;
 }
@@ -396,7 +398,7 @@ handle_deploy (FlatpakSystemHelper   *object,
 
   g_debug ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -706,7 +708,7 @@ handle_cancel_pull (FlatpakSystemHelper   *object,
 
   g_debug ("CancelPull %s %u %s", arg_installation, arg_flags, arg_src_dir);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CANCEL_PULL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -763,7 +765,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 
   g_debug ("DeployAppstream %s %u %s %s %s", arg_repo_path, arg_flags, arg_origin, arg_arch, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_APPSTREAM_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -920,7 +922,7 @@ handle_uninstall (FlatpakSystemHelper   *object,
 
   g_debug ("Uninstall %u %s %s", arg_flags, arg_ref, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -966,7 +968,7 @@ handle_install_bundle (FlatpakSystemHelper   *object,
 
   g_debug ("InstallBundle %s %u %s %s", arg_bundle_path, arg_flags, arg_remote, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_INSTALL_BUNDLE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1017,7 +1019,7 @@ handle_configure_remote (FlatpakSystemHelper   *object,
 
   g_debug ("ConfigureRemote %u %s %s", arg_flags, arg_remote, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1092,7 +1094,7 @@ handle_configure (FlatpakSystemHelper   *object,
 
   g_debug ("Configure %u %s=%s %s", arg_flags, arg_key, arg_value, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1157,7 +1159,7 @@ handle_update_remote (FlatpakSystemHelper   *object,
 
   g_debug ("UpdateRemote %u %s %s %s %s", arg_flags, arg_remote, arg_installation, arg_summary_path, arg_summary_sig_path);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1233,7 +1235,7 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
 
   g_debug ("RemoveLocalRef %u %s %s %s", arg_flags, arg_remote, arg_ref, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_REMOVE_LOCAL_REF_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1282,7 +1284,7 @@ handle_prune_local_repo (FlatpakSystemHelper   *object,
 
   g_debug ("PruneLocalRepo %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_PRUNE_LOCAL_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1326,7 +1328,7 @@ handle_ensure_repo (FlatpakSystemHelper   *object,
 
   g_debug ("EnsureRepo %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_ENSURE_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1365,7 +1367,7 @@ handle_run_triggers (FlatpakSystemHelper   *object,
 
   g_debug ("RunTriggers %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_RUN_TRIGGERS_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1656,7 +1658,7 @@ handle_get_revokefs_fd (FlatpakSystemHelper   *object,
       return TRUE;
     }
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_GET_REVOKEFS_FD_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1753,7 +1755,7 @@ handle_update_summary (FlatpakSystemHelper   *object,
 
   g_debug ("UpdateSummary %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1799,7 +1801,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
 
   g_debug ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1900,6 +1902,8 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
         {
           gboolean is_app, is_install;
 
+          no_interaction = (flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0;
+
           /* These flags allow clients to "upgrade" the permission,
            * avoiding the need for multiple polkit dialogs when we first
            * update a runtime, then install the app that needs it.
@@ -1920,7 +1924,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
             is_install = TRUE;
           else
             {
-              g_autoptr(FlatpakDir) system = dir_get_system (installation, 0, NULL);
+              g_autoptr(FlatpakDir) system = dir_get_system (installation, 0, no_interaction, NULL);
 
               is_install = !dir_ref_is_installed (system, ref);
             }
@@ -1939,8 +1943,6 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
               else
                 action = "org.freedesktop.Flatpak.runtime-update";
             }
-
-          no_interaction = (flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0;
         }
 
       polkit_details_insert (details, "origin", origin);


### PR DESCRIPTION
The system helper was already correctly using the `NO_INTERACTION` flag
in the D-Bus call flags to determine whether polkit calls from
`flatpak_authorize_method_handler()` should allow interactivity.

However, the system helper was not setting the no-interaction property
on the `FlatpakDir` used in the subsequent operation. When parental
controls are enabled, this sometimes results in polkit allowing
interaction when prompting for the `override-parental-controls` action,
even if the D-Bus call which activated the system helper specified the
`NO_INTERACTION` flag.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T31351

---

Simple backport of https://github.com/flatpak/flatpak/pull/4199, with some minor conflict resolution done on calls to `dir_get_system()`.