### PR TITLE
create-usb: Skip copying extra-data flatpaks

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -146,6 +146,7 @@ add_related (GHashTable   *all_refs,
       const char *ext_remote;
       const char *ext_commit = NULL;
       CommitAndSubpaths *c_s;
+      g_autoptr(GVariant) extra_data_sources = NULL;
 
       if (ext->is_unmaintained)
         continue;
@@ -178,6 +179,17 @@ add_related (GHashTable   *all_refs,
         }
 
       ext_commit = flatpak_deploy_data_get_commit (ext_deploy_data);
+
+      /* Emit a warning and omit it if it's extra-data
+       * https://github.com/flatpak/flatpak/issues/969 */
+      extra_data_sources = flatpak_repo_get_extra_data_sources (flatpak_dir_get_repo (dir), ext_commit, NULL, NULL);
+      if (extra_data_sources != NULL && g_variant_n_children (extra_data_sources) > 0)
+        {
+           g_printerr (_("Warning: Omitting related ref ‘%s’ because it's extra-data.\n"),
+                       ext->ref);
+           continue;
+        }
+
       ext_subpaths = flatpak_deploy_data_get_subpaths (ext_deploy_data);
       resolved_ext_subpaths = get_flatpak_subpaths_from_deploy_subpaths (ext_subpaths);
       c_s = commit_and_subpaths_new (ext_commit, (const char * const *) resolved_ext_subpaths);
@@ -216,6 +228,7 @@ add_runtime (GHashTable   *all_refs,
   const char *commit = NULL;
   const char *runtime_commit = NULL;
   CommitAndSubpaths *c_s;
+  g_autoptr(GVariant) extra_data_sources = NULL;
 
   g_debug ("Finding the runtime for ‘%s’", ref);
 
@@ -248,6 +261,17 @@ add_runtime (GHashTable   *all_refs,
                          runtime_remote, runtime_ref);
 
   runtime_commit = flatpak_deploy_data_get_commit (runtime_deploy_data);
+
+  /* Emit a warning and omit it if it's extra-data
+   * https://github.com/flatpak/flatpak/issues/969 */
+  extra_data_sources = flatpak_repo_get_extra_data_sources (flatpak_dir_get_repo (dir), runtime_commit, NULL, NULL);
+  if (extra_data_sources != NULL && g_variant_n_children (extra_data_sources) > 0)
+    {
+       g_printerr (_("Warning: Omitting ref ‘%s’ (runtime of ‘%s’) because it's extra-data.\n"),
+                   runtime_ref, ref);
+       return TRUE;
+    }
+
   runtime_subpaths = flatpak_deploy_data_get_subpaths (runtime_deploy_data);
   resolved_runtime_subpaths = get_flatpak_subpaths_from_deploy_subpaths (runtime_subpaths);
   c_s = commit_and_subpaths_new (runtime_commit, (const char * const *) resolved_runtime_subpaths);
@@ -634,6 +658,7 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
       /* Add the main ref */
       {
         g_autoptr(GBytes) deploy_data = NULL;
+        g_autoptr(GVariant) extra_data_sources = NULL;
         const char *commit;
         CommitAndSubpaths *c_s;
 
@@ -646,6 +671,16 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
                       installed_ref);
 
         commit = flatpak_deploy_data_get_commit (deploy_data);
+
+        /* Extra-data flatpaks can't be copied to a USB (the installation will
+         * fail on the receiving end if they're offline) so error out if one
+         * was specified. https://github.com/flatpak/flatpak/issues/969 */
+        extra_data_sources = flatpak_repo_get_extra_data_sources (flatpak_dir_get_repo (dir), commit, NULL, NULL);
+        if (extra_data_sources != NULL && g_variant_n_children (extra_data_sources) > 0)
+          return flatpak_fail (error,
+                               _("Installed ref ‘%s’ is extra-data, and cannot be distributed offline"),
+                               installed_ref);
+
         c_s = commit_and_subpaths_new (commit, NULL);
 
         g_hash_table_insert (all_collection_ids, g_strdup (ref_collection_id), g_strdup (remote));


### PR DESCRIPTION
Currently the create-usb command copies extra-data flatpaks such as the
org.freedesktop.Platform.openh264 runtime extension along with normal
non-extra-data content. This is an issue because on the computer
installing from the USB it will attempt to get the extra-data content
from the URI specified in the commit metadata, which will fail if the
URI is a resource on the Internet and the computer is offline.

Instead, have create-usb omit such refs. If it was specified explicitly
this is treated as a hard error and if it's a dependency it's treated as
a warning, so that e.g. org.freedesktop.Platform can still be copied to
a USB and installed/updated offline. On the receiving end the absence of
org.freedesktop.Platform.openh264 will correctly not be treated as fatal
to the installation of org.freedesktop.Platform.

This issue was affecting offline updates of Endless OS, since such OS
updates include flatpaks along with the OS content.

For the (legally questionable) topic of properly supporting extra-data
distribution offline, see https://github.com/flatpak/flatpak/issues/969

(cherry picked from commit 0bf8cf9a08c8a7c6af3fc90100185051a76cd410)

Note: There were merge conflicts in the cherry-pick because upstream
uses FlatpakDecomposed instead of plain strings to represent refs.

https://phabricator.endlessm.com/T31641