### PR TITLE
Backport various fixes needed to fix eos-updater unit tests

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -100,7 +100,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
                   g_autoptr(FlatpakDir) src_dir = NULL;
                   g_autoptr(GFile) deploy = NULL;
                   g_autoptr(GBytes) deploy_data = NULL;
-                  const char **subpaths;
+                  g_autofree const char **subpaths = NULL;
 
                   deploy = flatpak_find_deploy_dir_for_ref (ext->ref, &src_dir, cancellable, error);
                   if (deploy == NULL)

--- a/app/flatpak-builtins-document-export.c
+++ b/app/flatpak-builtins-document-export.c
@@ -90,8 +90,8 @@ flatpak_builtin_document_export (int argc, char **argv,
   g_autofree char *dirname = NULL;
   g_autofree char *doc_path = NULL;
   XdpDbusDocuments *documents;
-  int fd, fd_id;
-  int i;
+  glnx_autofd int fd = -1;
+  int i, fd_id;
   GUnixFDList *fd_list = NULL;
   const char *doc_id;
   struct stat stbuf;
@@ -173,7 +173,7 @@ flatpak_builtin_document_export (int argc, char **argv,
 
   fd_list = g_unix_fd_list_new ();
   fd_id = g_unix_fd_list_append (fd_list, fd, error);
-  close (fd);
+  glnx_close_fd (&fd);
 
   if (opt_noexist)
     {

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -513,12 +513,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
           g_autoptr(FlatpakRemoteState) state = NULL;
 
           state = flatpak_transaction_ensure_remote_state (transaction, FLATPAK_TRANSACTION_OPERATION_INSTALL,
-                                                           remote, error);
+                                                           remote, arch, error);
           if (state == NULL)
-            return FALSE;
-
-          if (arch != NULL &&
-              !flatpak_remote_state_ensure_subsummary (state, dir, arch, FALSE, cancellable, error))
             return FALSE;
 
           refs = flatpak_dir_find_remote_refs (dir, state, id, branch, default_branch, arch,

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -423,6 +423,7 @@ flatpak_builtin_list (int argc, char **argv, GCancellable *cancellable, GError *
   if (dirs->len > 1)
     {
       int c = find_column (all_columns, "installation", NULL);
+      g_assert (c != -1);
       all_columns[c].def = 1;
     }
 

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -280,7 +280,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       print_aligned (len, _("ID:"), id);
       print_aligned (len, _("Ref:"), flatpak_decomposed_get_ref (ref));
       print_aligned_take (len, _("Arch:"), flatpak_decomposed_dup_arch (ref));
-      print_aligned (len, _("Branch:"), flatpak_decomposed_dup_arch (ref));
+      print_aligned (len, _("Branch:"), flatpak_decomposed_dup_branch (ref));
       if (version != NULL)
         print_aligned (len, _("Version:"), version);
       if (license != NULL)

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -280,7 +280,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       print_aligned (len, _("ID:"), id);
       print_aligned (len, _("Ref:"), flatpak_decomposed_get_ref (ref));
       print_aligned_take (len, _("Arch:"), flatpak_decomposed_dup_arch (ref));
-      print_aligned (len, _("Branch:"), flatpak_decomposed_dup_branch (ref));
+      print_aligned_take (len, _("Branch:"), flatpak_decomposed_dup_branch (ref));
       if (version != NULL)
         print_aligned (len, _("Version:"), version);
       if (license != NULL)

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -197,8 +197,10 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
                   if (flatpak_dir_get_remote_noenumerate (dir, remote_name))
                     flatpak_table_printer_append_with_comma (printer, "no-enumerate");
 
-                  ostree_repo_remote_get_gpg_verify (flatpak_dir_get_repo (dir), remote_name,
-                                                     &gpg_verify, NULL);
+                  if (!ostree_repo_remote_get_gpg_verify (flatpak_dir_get_repo (dir), remote_name,
+                                                          &gpg_verify, error))
+                      return FALSE; /* shouldn't happen unless repo config is modified out-of-band */
+
                   if (!gpg_verify)
                     flatpak_table_printer_append_with_comma (printer, "no-gpg-verify");
 

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -256,7 +256,7 @@ transaction_add_local_ref (FlatpakDir         *dir,
   g_autoptr(GError) local_error = NULL;
   g_autofree char *repo_checksum = NULL;
   const char *origin;
-  const char **subpaths;
+  g_autofree const char **subpaths = NULL;
 
   deploy_data = flatpak_dir_get_deploy_data (dir, ref, FLATPAK_DEPLOY_VERSION_ANY, NULL, &local_error);
   if (deploy_data == NULL)

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -194,6 +194,12 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
       g_autoptr(GError) local_error2 = NULL;
       g_autoptr(GPtrArray) ref_dir_pairs = NULL;
       RefDirPair *chosen_pair = NULL;
+      const char *runtime_arch = arch;
+
+      /* If arch is not specified, only run the default arch to avoid asking for prompts for non-primary arches,
+         still asks for prompts if there are multiple branches though */
+      if (runtime_arch == NULL)
+        runtime_arch = flatpak_get_arch ();
 
       /* Whereas for apps we want to default to using the "current" one (see
        * flatpak-make-current(1)) runtimes don't have a concept of currentness.
@@ -204,7 +210,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
           g_autoptr(GPtrArray) refs = NULL;
 
-          refs = flatpak_dir_find_installed_refs (dir, id, branch, arch, FLATPAK_KINDS_RUNTIME,
+          refs = flatpak_dir_find_installed_refs (dir, id, branch, runtime_arch, FLATPAK_KINDS_RUNTIME,
                                                   FIND_MATCHING_REFS_FLAGS_NONE, error);
           if (refs == NULL)
             return FALSE;

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1390,6 +1390,7 @@ get_remote_state (FlatpakDir   *dir,
   return state;
 }
 
+/* Note: cached == TRUE here means prefer-cache, not only-cache */
 gboolean
 ensure_remote_state_arch (FlatpakDir         *dir,
                           FlatpakRemoteState *state,
@@ -1429,6 +1430,7 @@ ensure_remote_state_arch_for_ref (FlatpakDir         *dir,
   return ensure_remote_state_arch (dir, state, ref_arch, cached, only_sideloaded,cancellable, error);
 }
 
+/* Note: cached == TRUE here means prefer-cache, not only-cache */
 gboolean
 ensure_remote_state_all_arches (FlatpakDir         *dir,
                                 FlatpakRemoteState *state,
@@ -1437,15 +1439,19 @@ ensure_remote_state_all_arches (FlatpakDir         *dir,
                                 GCancellable       *cancellable,
                                 GError            **error)
 {
-  if (state->index_ht == NULL)
+  if (only_sideloaded)
     return TRUE;
 
-  GLNX_HASH_TABLE_FOREACH (state->index_ht, const char *, arch)
+  if (cached)
     {
-      if (!ensure_remote_state_arch (dir, state, arch,
-                                     cached, only_sideloaded,
-                                     cancellable, error))
+      /* First try cached, this will not error on uncached arches */
+      if (!flatpak_remote_state_ensure_subsummary_all_arches (state, dir, TRUE, cancellable, error))
         return FALSE;
     }
+
+  /* Then download rest */
+  if (!flatpak_remote_state_ensure_subsummary_all_arches (state, dir, FALSE, cancellable, error))
+    return FALSE;
+
   return TRUE;
 }

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1126,7 +1126,10 @@ transaction_ready_pre_auth (FlatpakTransaction *transaction)
 
   flatpak_table_printer_set_column_expand (printer, i, TRUE);
   if (!self->non_default_arch)
-    flatpak_table_printer_set_column_skip_unique (printer, i, TRUE);
+    {
+      flatpak_table_printer_set_column_skip_unique (printer, i, TRUE);
+      flatpak_table_printer_set_column_skip_unique_string (printer, i, flatpak_get_arch ());
+    }
   flatpak_table_printer_set_column_title (printer, i++, _("Arch"));
 
   flatpak_table_printer_set_column_expand (printer, i, TRUE);

--- a/app/flatpak-table-printer.h
+++ b/app/flatpak-table-printer.h
@@ -96,5 +96,9 @@ void               flatpak_table_printer_set_column_ellipsize (FlatpakTablePrint
 void               flatpak_table_printer_set_column_skip_unique (FlatpakTablePrinter *printer,
                                                                  int                  column,
                                                                  gboolean             skip_unique);
+void               flatpak_table_printer_set_column_skip_unique_string (FlatpakTablePrinter *printer,
+                                                                        int                  column,
+                                                                        const char          *str);
+
 
 #endif /* __FLATPAK_TABLE_PRINTER_H__ */

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1149,6 +1149,8 @@ option_env_fd_cb (const gchar *option_name,
     {
       size_t len = strnlen (p, remaining);
       const char *equals;
+      g_autofree char *env_var = NULL;
+      g_autofree char *env_value = NULL;
 
       g_assert (len <= remaining);
 
@@ -1158,9 +1160,9 @@ option_env_fd_cb (const gchar *option_name,
         return glnx_throw (error,
                            "Environment variable must be given in the form VARIABLE=VALUE, not %.*s", (int) len, p);
 
-      flatpak_context_set_env_var (context,
-                                   g_strndup (p, equals - p),
-                                   g_strndup (equals + 1, len - (equals - p) - 1));
+      env_var = g_strndup (p, equals - p);
+      env_value = g_strndup (equals + 1, len - (equals - p) - 1);
+      flatpak_context_set_env_var (context, env_var, env_value);
       p += len;
       remaining -= len;
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -155,6 +155,11 @@ gboolean flatpak_remote_state_ensure_subsummary (FlatpakRemoteState *self,
                                                  gboolean            only_cached,
                                                  GCancellable       *cancellable,
                                                  GError            **error);
+gboolean flatpak_remote_state_ensure_subsummary_all_arches (FlatpakRemoteState *self,
+                                                            FlatpakDir         *dir,
+                                                            gboolean            only_cached,
+                                                            GCancellable       *cancellable,
+                                                            GError            **error);
 gboolean flatpak_remote_state_allow_ref (FlatpakRemoteState *self,
                                          const char *ref);
 gboolean flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -506,6 +506,35 @@ flatpak_remote_state_ensure_subsummary (FlatpakRemoteState *self,
 }
 
 gboolean
+flatpak_remote_state_ensure_subsummary_all_arches (FlatpakRemoteState *self,
+                                                   FlatpakDir         *dir,
+                                                   gboolean            only_cached,
+                                                   GCancellable       *cancellable,
+                                                   GError            **error)
+{
+  if (self->index_ht == NULL)
+    return TRUE; /* No subsummaries, got all arches anyway */
+
+  GLNX_HASH_TABLE_FOREACH (self->index_ht, const char *, arch)
+    {
+      g_autoptr(GError) local_error = NULL;
+
+      if (!flatpak_remote_state_ensure_subsummary (self, dir, arch, only_cached, cancellable, &local_error))
+        {
+          /* Don't error on non-cached subsummaries */
+          if (only_cached && g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_CACHED))
+            continue;
+
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+
+gboolean
 flatpak_remote_state_allow_ref (FlatpakRemoteState *self,
                                 const char *ref)
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13745,14 +13745,15 @@ parse_ref_file (GKeyFile *keyfile,
   collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                          FLATPAK_REF_DEPLOY_COLLECTION_ID_KEY, NULL);
 
-  if (collection_id == NULL || *collection_id == '\0')
+  if (collection_id != NULL && *collection_id == '\0')
+    g_clear_pointer (&collection_id, g_free);
+  if (collection_id == NULL)
     {
       collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                              FLATPAK_REF_COLLECTION_ID_KEY, NULL);
     }
-
   if (collection_id != NULL && *collection_id == '\0')
-    collection_id = NULL;
+    g_clear_pointer (&collection_id, g_free);
 
   if (collection_id != NULL && gpg_data == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Collection ID requires GPG key to be provided"));

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6995,7 +6995,6 @@ export_desktop_file (const char         *app,
                      GCancellable       *cancellable,
                      GError            **error)
 {
-  gboolean ret = FALSE;
   glnx_autofd int desktop_fd = -1;
   g_autofree char *tmpfile_name = g_strdup_printf ("export-desktop-XXXXXX");
   g_autoptr(GOutputStream) out_stream = NULL;
@@ -7008,21 +7007,20 @@ export_desktop_file (const char         *app,
   gint old_argc;
   g_auto(GStrv) old_argv = NULL;
   g_auto(GStrv) groups = NULL;
-  GString *new_exec = NULL;
   g_autofree char *escaped_app = maybe_quote (app);
   g_autofree char *escaped_branch = maybe_quote (branch);
   g_autofree char *escaped_arch = maybe_quote (arch);
   int i;
 
   if (!flatpak_openat_noatime (parent_fd, name, &desktop_fd, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (!read_fd (desktop_fd, stat_buf, &data, &data_len, error))
-    goto out;
+    return FALSE;
 
   keyfile = g_key_file_new ();
   if (!g_key_file_load_from_data (keyfile, data, data_len, G_KEY_FILE_KEEP_TRANSLATIONS, error))
-    goto out;
+    return FALSE;
 
   if (g_str_has_suffix (name, ".service"))
     {
@@ -7122,6 +7120,7 @@ export_desktop_file (const char         *app,
 
   for (i = 0; groups[i] != NULL; i++)
     {
+      g_autoptr(GString) new_exec = NULL;
       g_auto(GStrv) flatpak_run_opts = g_key_file_get_string_list (keyfile, groups[i], "X-Flatpak-RunOptions", NULL, NULL);
       g_autofree char *flatpak_run_args = format_flatpak_run_args_from_run_opts (flatpak_run_opts);
 
@@ -7173,7 +7172,7 @@ export_desktop_file (const char         *app,
                 {
                   flatpak_fail_error (error, FLATPAK_ERROR_EXPORT_FAILED,
                                      _("Invalid Exec argument %s"), arg);
-                  goto out;
+                  return FALSE;
                 }
               else
                 g_string_append_printf (new_exec, " %s", arg);
@@ -7190,27 +7189,21 @@ export_desktop_file (const char         *app,
 
   new_data = g_key_file_to_data (keyfile, &new_data_len, error);
   if (new_data == NULL)
-    goto out;
+    return FALSE;
 
   if (!flatpak_open_in_tmpdir_at (parent_fd, 0755, tmpfile_name, &out_stream, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (!g_output_stream_write_all (out_stream, new_data, new_data_len, NULL, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (!g_output_stream_close (out_stream, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (target)
     *target = g_steal_pointer (&tmpfile_name);
 
-  ret = TRUE;
-out:
-
-  if (new_exec != NULL)
-    g_string_free (new_exec, TRUE);
-
-  return ret;
+  return TRUE;
 }
 
 static gboolean

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11871,6 +11871,7 @@ flatpak_dir_remote_fetch_indexed_summary (FlatpakDir   *self,
           if (summary == NULL)
             return FALSE;
 
+          g_free (sha256);
           sha256 = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, summary);
           if (strcmp (sha256, checksum) != 0)
             return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid checksum for indexed summary %s for remote '%s'"), checksum, name_or_uri);
@@ -12541,12 +12542,11 @@ find_matching_ref (GHashTable  *refs,
             g_string_append (err, ", ");
 
           const char *branch = flatpak_decomposed_get_branch (ref);
-
-          g_string_append (err,
-                           g_strdup_printf ("%s/%s/%s",
-                                            name,
-                                            opt_arch ? opt_arch : "",
-                                            branch));
+          g_string_append_printf (err,
+                                  "%s/%s/%s",
+                                  name,
+                                  opt_arch ? opt_arch : "",
+                                  branch);
         }
 
       flatpak_fail (error, "%s", err->str);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3107,6 +3107,11 @@ flatpak_deploy_data_get_eol_rebase (GBytes *deploy_data)
   return flatpak_deploy_data_get_string (deploy_data, "eolr");
 }
 
+/*<private>
+ * flatpak_deploy_data_get_previous_ids:
+ *
+ * Returns: (array length=length zero-terminated=1) (transfer container): an array of constant strings
+ **/
 const char **
 flatpak_deploy_data_get_previous_ids (GBytes *deploy_data, gsize *length)
 {
@@ -8701,7 +8706,8 @@ flatpak_dir_deploy_update (FlatpakDir        *self,
   g_autofree char *old_active = NULL;
   const char *old_origin;
   g_autofree char *commit = NULL;
-  g_auto(GStrv) previous_ids = NULL;
+  g_autofree const char **previous_ids = NULL;
+  g_auto(GStrv) previous_ids_owned = NULL;
 
   if (!flatpak_dir_lock (self, &lock,
                          cancellable, error))
@@ -8718,19 +8724,21 @@ flatpak_dir_deploy_update (FlatpakDir        *self,
   old_origin = flatpak_deploy_data_get_origin (old_deploy_data);
   old_subpaths = flatpak_deploy_data_get_subpaths (old_deploy_data);
 
-  previous_ids = g_strdupv ((char **) flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL));
+  previous_ids = flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL);
   if (opt_previous_ids)
     {
-      g_auto(GStrv) old_previous_ids = previous_ids;
-      previous_ids = flatpak_strv_merge (old_previous_ids, (char **) opt_previous_ids);
+      previous_ids_owned = flatpak_strv_merge ((char **) previous_ids, (char **) opt_previous_ids);
+      g_clear_pointer (&previous_ids, g_free);
     }
+  else
+    previous_ids_owned = g_strdupv ((char **) previous_ids);
 
   if (!flatpak_dir_deploy (self,
                            old_origin,
                            ref,
                            checksum_or_latest,
                            opt_subpaths ? opt_subpaths : old_subpaths,
-                           (const char * const *) previous_ids,
+                           (const char * const *) previous_ids_owned,
                            cancellable, error))
     return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -12421,22 +12421,17 @@ find_matching_refs (GHashTable           *refs,
                     const char           *opt_name,
                     const char           *opt_branch,
                     const char           *opt_default_branch,
-                    const char           *opt_arch,
+                    const char          **valid_arches, /* NULL => any arch */
                     const char           *opt_default_arch,
                     FlatpakKinds          kinds,
                     FindMatchingRefsFlags flags,
                     GError              **error)
 {
   g_autoptr(GPtrArray) matched_refs = NULL;
-  const char **arches = flatpak_get_arches ();
-  const char *opt_arches[] = {opt_arch, NULL};
   g_autoptr(GError) local_error = NULL;
   gboolean found_exact_name_match = FALSE;
   gboolean found_default_branch_match = FALSE;
   gboolean found_default_arch_match = FALSE;
-
-  if (opt_arch != NULL)
-    arches = opt_arches;
 
   if (opt_name && !(flags & FIND_MATCHING_REFS_FLAGS_FUZZY) &&
       !flatpak_is_valid_name (opt_name, -1, &local_error))
@@ -12472,7 +12467,8 @@ find_matching_refs (GHashTable           *refs,
            }
         }
 
-      if (!flatpak_decomposed_is_arches (ref, -1, arches))
+      if (valid_arches != NULL &&
+          !flatpak_decomposed_is_arches (ref, -1, valid_arches))
         continue;
 
       if (opt_branch != NULL && !flatpak_decomposed_is_branch (ref, opt_branch))
@@ -12513,66 +12509,91 @@ find_matching_refs (GHashTable           *refs,
   return g_steal_pointer (&matched_refs);
 }
 
+static GPtrArray *
+get_refs_for_arch (GPtrArray *refs, const char *arch)
+{
+  g_autoptr(GPtrArray) arched_refs = g_ptr_array_new_with_free_func ((GDestroyNotify)flatpak_decomposed_unref);
+
+  for (int i = 0; i < refs->len; i++)
+    {
+      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
+      if (flatpak_decomposed_is_arch (ref, arch))
+        g_ptr_array_add (arched_refs, flatpak_decomposed_ref (ref));
+    }
+
+  return g_steal_pointer (&arched_refs);
+}
+
+static gpointer
+fail_multiple_refs (GError    **error,
+                    const char *name,
+                    GPtrArray  *refs)
+{
+  g_autoptr(GString) err = g_string_new ("");
+
+  g_string_printf (err, _("Multiple branches available for %s, you must specify one of: "), name);
+  g_ptr_array_sort (refs, flatpak_strcmp0_ptr);
+
+  for (int i = 0; i < refs->len; i++)
+    {
+      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
+      if (i != 0)
+        g_string_append (err, ", ");
+
+      g_string_append (err, flatpak_decomposed_get_pref (ref));
+    }
+  flatpak_fail (error, "%s", err->str);
+
+  return NULL;
+}
+
 static FlatpakDecomposed *
 find_matching_ref (GHashTable  *refs,
                    const char  *name,
                    const char  *opt_branch,
                    const char  *opt_default_branch,
-                   const char  *opt_arch,
+                   const char **valid_arches, /* NULL => any arch */
+                   const char  *opt_default_arch,
                    FlatpakKinds kinds,
                    GError     **error)
 {
-  const char **arches = flatpak_get_arches ();
-  const char *opt_arches[] = {opt_arch, NULL};
-  int i;
+  g_autoptr(GPtrArray) matched_refs = NULL;
 
-  if (opt_arch != NULL)
-    arches = opt_arches;
+  matched_refs = find_matching_refs (refs,
+                                     name,
+                                     opt_branch,
+                                     opt_default_branch,
+                                     valid_arches,
+                                     opt_default_arch,
+                                     kinds,
+                                     FIND_MATCHING_REFS_FLAGS_NONE,
+                                     error);
+  if (matched_refs == NULL)
+    return NULL;
 
-  /* We stop at the first arch (in prio order) that has a match */
-  for (i = 0; arches[i] != NULL; i++)
+  if (valid_arches != NULL)
     {
-      g_autoptr(GPtrArray) matched_refs = NULL;
-      int j;
+      /* Filter by valid, arch. We stop at the first arch (in prio order) that has a match */
+      for (int i = 0; valid_arches[i] != NULL; i++)
+        {
+          const char *arch = valid_arches[i];
 
-      matched_refs = find_matching_refs (refs,
-                                         name,
-                                         opt_branch,
-                                         opt_default_branch,
-                                         arches[i],
-                                         NULL,
-                                         kinds,
-                                         FIND_MATCHING_REFS_FLAGS_NONE,
-                                         error);
-      if (matched_refs == NULL)
-        return NULL;
+          g_autoptr(GPtrArray) arched_refs = get_refs_for_arch (matched_refs, arch);
 
-      if (matched_refs->len == 0)
-        continue;
+          if (arched_refs->len == 1)
+            return flatpak_decomposed_ref (g_ptr_array_index (arched_refs, 0));
 
+          if (arched_refs->len > 1)
+            return fail_multiple_refs (error, name, arched_refs);
+        }
+    }
+  else
+    {
       if (matched_refs->len == 1)
         return flatpak_decomposed_ref (g_ptr_array_index (matched_refs, 0));
 
-      /* Nothing to do other than reporting the different choices */
-      g_autoptr(GString) err = g_string_new ("");
-      g_string_printf (err, _("Multiple branches available for %s, you must specify one of: "), name);
-      g_ptr_array_sort (matched_refs, flatpak_strcmp0_ptr);
-      for (j = 0; j < matched_refs->len; j++)
-        {
-          FlatpakDecomposed *ref = g_ptr_array_index (matched_refs, j);
-          if (j != 0)
-            g_string_append (err, ", ");
-
-          const char *branch = flatpak_decomposed_get_branch (ref);
-          g_string_append_printf (err,
-                                  "%s/%s/%s",
-                                  name,
-                                  opt_arch ? opt_arch : "",
-                                  branch);
-        }
-
-      flatpak_fail (error, "%s", err->str);
-      return NULL;
+      if (matched_refs->len > 1)
+        return fail_multiple_refs (error, name, matched_refs);
     }
 
   g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
@@ -12594,6 +12615,9 @@ flatpak_dir_get_remote_collection_id (FlatpakDir *self,
   return collection_id;
 }
 
+/* This tries to find all available refs based on the specified name/branch/arch
+ * triplet from  a remote. If arch is not specified, matches only on compatible arches.
+*/
 GPtrArray *
 flatpak_dir_find_remote_refs (FlatpakDir           *self,
                               FlatpakRemoteState   *state,
@@ -12609,17 +12633,21 @@ flatpak_dir_find_remote_refs (FlatpakDir           *self,
 {
   g_autoptr(GHashTable) remote_refs = NULL;
   g_autoptr(GPtrArray) matched_refs = NULL;
+  const char **valid_arches = flatpak_get_arches ();
+  const char *opt_arches[] = {opt_arch, NULL};
+
+  if (opt_arch != NULL)
+    valid_arches = opt_arches;
 
   if (!flatpak_dir_list_all_remote_refs (self, state,
                                          &remote_refs, cancellable, error))
     return NULL;
 
-
   matched_refs = find_matching_refs (remote_refs,
                                      name,
                                      opt_branch,
                                      opt_default_branch,
-                                     opt_arch,
+                                     valid_arches,
                                      opt_default_arch,
                                      kinds,
                                      flags,
@@ -12646,12 +12674,19 @@ find_ref_for_refs_set (GHashTable   *refs,
                        FlatpakKinds  kinds,
                        GError      **error)
 {
+  const char **valid_arches = flatpak_get_arches ();
+  const char *opt_arches[] = {opt_arch, NULL};
+
+  if (opt_arch != NULL)
+    valid_arches = opt_arches;
+
   g_autoptr(GError) my_error = NULL;
   g_autoptr(FlatpakDecomposed) ref = find_matching_ref (refs,
                                                         name,
                                                         opt_branch,
                                                         opt_default_branch,
-                                                        opt_arch,
+                                                        valid_arches,
+                                                        NULL,
                                                         kinds,
                                                         &my_error);
   if (ref == NULL)
@@ -12679,6 +12714,9 @@ find_ref_for_refs_set (GHashTable   *refs,
   return NULL;
 }
 
+/* This tries to find a single ref based on the specfied name/branch/arch
+ * triplet from  a remote. If arch is not specified, matches only on compatible arches.
+*/
 FlatpakDecomposed *
 flatpak_dir_find_remote_ref (FlatpakDir   *self,
                              FlatpakRemoteState *state,
@@ -12777,6 +12815,11 @@ flatpak_dir_find_local_refs (FlatpakDir           *self,
   g_autoptr(GError) my_error = NULL;
   g_autofree char *refspec_prefix = g_strconcat (remote, ":.", NULL);
   g_autoptr(GPtrArray) matched_refs = NULL;
+  const char **valid_arches = flatpak_get_arches ();
+  const char *opt_arches[] = {opt_arch, NULL};
+
+  if (opt_arch != NULL)
+    valid_arches = opt_arches;
 
   if (!flatpak_dir_ensure_repo (self, NULL, error))
     return NULL;
@@ -12792,7 +12835,7 @@ flatpak_dir_find_local_refs (FlatpakDir           *self,
                                      name,
                                      opt_branch,
                                      opt_default_branch,
-                                     opt_arch,
+                                     valid_arches,
                                      opt_default_arch,
                                      kinds,
                                      flags,
@@ -12855,6 +12898,9 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
   return g_steal_pointer (&local_refs);
 }
 
+/* This tries to find a all installed refs based on the specfied name/branch/arch
+ * triplet. Matches on all arches.
+*/
 GPtrArray *
 flatpak_dir_find_installed_refs (FlatpakDir           *self,
                                  const char           *opt_name,
@@ -12866,6 +12912,11 @@ flatpak_dir_find_installed_refs (FlatpakDir           *self,
 {
   g_autoptr(GHashTable) local_refs = NULL;
   g_autoptr(GPtrArray) matched_refs = NULL;
+  const char **valid_arches = NULL; /* List all installed arches if unspecified */
+  const char *opt_arches[] = {opt_arch, NULL};
+
+  if (opt_arch != NULL)
+    valid_arches = opt_arches;
 
   local_refs = flatpak_dir_get_all_installed_refs (self, kinds, error);
   if (local_refs == NULL)
@@ -12875,7 +12926,7 @@ flatpak_dir_find_installed_refs (FlatpakDir           *self,
                                      opt_name,
                                      opt_branch,
                                      NULL, /* default branch */
-                                     opt_arch,
+                                     valid_arches,
                                      NULL, /* default arch */
                                      kinds,
                                      flags,
@@ -12886,6 +12937,10 @@ flatpak_dir_find_installed_refs (FlatpakDir           *self,
   return g_steal_pointer (&matched_refs);
 }
 
+/* This tries to find a single ref based on the specfied name/branch/arch
+ * triplet. This matches on all (installed) arches, but defaults to the primary
+ * arch if that is installed. Otherwise, ambiguity is an error.
+*/
 FlatpakDecomposed *
 flatpak_dir_find_installed_ref (FlatpakDir   *self,
                                 const char   *opt_name,
@@ -12897,13 +12952,20 @@ flatpak_dir_find_installed_ref (FlatpakDir   *self,
   g_autoptr(FlatpakDecomposed) local_ref = NULL;
   g_autoptr(GHashTable) local_refs = NULL;
   g_autoptr(GError) my_error = NULL;
+  const char **valid_arches = NULL; /* All are valid unless specified in opt_arch */
+  const char *default_arch = flatpak_get_arch ();
+  const char *opt_arches[] = {opt_arch, NULL};
+
+  if (opt_arch != NULL)
+    valid_arches = opt_arches;
 
   local_refs = flatpak_dir_get_all_installed_refs (self, kinds, error);
   if (local_refs == NULL)
     return NULL;
 
   local_ref = find_matching_ref (local_refs, opt_name, opt_branch, NULL,
-                                 opt_arch, kinds, &my_error);
+                                 valid_arches, default_arch,
+                                 kinds, &my_error);
   if (local_ref == NULL)
     {
       if (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -2417,22 +2417,35 @@ flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
   GHashTableIter iter;
   gpointer key;
   gpointer value;
+  gboolean only_sideloaded = (flags & FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED) != 0;
+  gboolean only_cached = (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0;
+  gboolean all_arches = (flags & FLATPAK_QUERY_FLAGS_ALL_ARCHES) != 0;
 
   dir = flatpak_installation_get_dir (self, error);
   if (dir == NULL)
     return NULL;
 
-  if (flags & FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED)
-    state = flatpak_dir_get_remote_state_local_only (dir, remote_or_uri, cancellable, error);
+  if (only_sideloaded)
+    {
+      state = flatpak_dir_get_remote_state_local_only (dir, remote_or_uri, cancellable, error);
+      if (state == NULL)
+        return NULL;
+    }
   else
-    state = flatpak_dir_get_remote_state (dir, remote_or_uri, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0, cancellable, error);
-  if (state == NULL)
-    return NULL;
+    {
+      state = flatpak_dir_get_remote_state (dir, remote_or_uri, only_cached, cancellable, error);
+      if (state == NULL)
+        return NULL;
+
+      if (all_arches &&
+          !flatpak_remote_state_ensure_subsummary_all_arches (state, dir, only_cached, cancellable, error))
+        return NULL;
+    }
 
   if (!flatpak_dir_list_remote_refs (dir, state, &ht,
                                      cancellable, &local_error))
     {
-      if (flags & FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED)
+      if (only_sideloaded)
         {
           /* Just return no sideloaded refs rather than a summary download failed error if there are none */
           return g_steal_pointer (&refs);

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -131,6 +131,7 @@ typedef enum {
  * lot more efficient if you're doing many requests.
  * @FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED: Only list refs available from sideload
  * repos; see flatpak(1). (Snce: 1.7)
+ * @FLATPAK_QUERY_FLAGS_ALL_ARCHES: Include refs from all arches, not just the primary ones. (Snce: 1.11.2)
  *
  * Flags to alter the behavior of e.g flatpak_installation_list_remote_refs_sync_full().
  *
@@ -140,6 +141,7 @@ typedef enum {
   FLATPAK_QUERY_FLAGS_NONE        = 0,
   FLATPAK_QUERY_FLAGS_ONLY_CACHED = (1 << 0),
   FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED = (1 << 1),
+  FLATPAK_QUERY_FLAGS_ALL_ARCHES = (1 << 2),
 } FlatpakQueryFlags;
 
 /**

--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -182,14 +182,14 @@ update_status_progress_and_estimating (FlatpakProgress *self)
   gboolean last_was_metadata = self->last_was_metadata;
   g_autofree gchar *formatted_bytes_total_transferred = NULL;
 
-  buf = g_string_new ("");
-
   /* We get some extra calls before we've really started due to the initialization of the
      extra data, so ignore those */
   if (self->requested == 0)
     {
       return;
     }
+
+  buf = g_string_new ("");
 
   /* The heuristic here goes as follows:
    *  - While fetching metadata, grow up to 5%

--- a/common/flatpak-transaction-private.h
+++ b/common/flatpak-transaction-private.h
@@ -27,6 +27,7 @@
 FlatpakRemoteState *flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
                                                              FlatpakTransactionOperationType kind,
                                                              const char                     *remote,
+                                                             const char                     *opt_arch,
                                                              GError                        **error);
 
 FlatpakDecomposed * flatpak_transaction_operation_get_decomposed (FlatpakTransactionOperation *self);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1904,23 +1904,26 @@ FlatpakRemoteState *
 flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
                                          FlatpakTransactionOperationType kind,
                                          const char                     *remote,
+                                         const char                     *opt_arch,
                                          GError                        **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
-  FlatpakRemoteState *state;
+  g_autoptr(FlatpakRemoteState) state = NULL;
+  FlatpakRemoteState *cached_state;
 
   /* We don't cache local-only states, as we might later need the same state with non-local state */
   if (transaction_is_local_only (self, kind))
     return flatpak_dir_get_remote_state_local_only (priv->dir, remote, NULL, error);
 
-  state = g_hash_table_lookup (priv->remote_states, remote);
-  if (state)
-    return flatpak_remote_state_ref (state);
-
-  state = flatpak_dir_get_remote_state_optional (priv->dir, remote, FALSE, NULL, error);
-
-  if (state)
+  cached_state = g_hash_table_lookup (priv->remote_states, remote);
+  if (cached_state)
+    state = flatpak_remote_state_ref (cached_state);
+  else
     {
+      state = flatpak_dir_get_remote_state_optional (priv->dir, remote, FALSE, NULL, error);
+      if (state == NULL)
+        return NULL;
+
       g_hash_table_insert (priv->remote_states, state->remote_name, flatpak_remote_state_ref (state));
 
       for (int i = 0; i < priv->extra_sideload_repos->len; i++)
@@ -1931,7 +1934,11 @@ flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
         }
     }
 
-  return state;
+  if (opt_arch != NULL &&
+      !flatpak_remote_state_ensure_subsummary (state, priv->dir, opt_arch, FALSE, NULL, error))
+    return FALSE;
+
+  return g_steal_pointer (&state);
 }
 
 static gboolean
@@ -2042,7 +2049,7 @@ op_get_related (FlatpakTransaction           *self,
 
   if (op->kind != FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
     {
-      state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, error);
+      state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, NULL, error);
       if (state == NULL)
         return FALSE;
     }
@@ -2189,7 +2196,7 @@ search_for_dependency (FlatpakTransaction  *self,
       g_autoptr(GError) local_error = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
 
-      state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, &local_error);
+      state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, NULL, &local_error);
       if (state == NULL)
         {
           g_debug ("Can't get state for remote %s: %s", remote, local_error->message);
@@ -2510,7 +2517,9 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
    * remote to be fatal */
   if (kind != FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
     {
-      state = flatpak_transaction_ensure_remote_state (self, kind, remote, error);
+      g_autofree char *arch = flatpak_decomposed_dup_arch (ref);
+
+      state = flatpak_transaction_ensure_remote_state (self, kind, remote, arch, error);
       if (state == NULL)
         return FALSE;
     }
@@ -2793,7 +2802,7 @@ flatpak_transaction_update_metadata (FlatpakTransaction *self,
       char *remote = remotes[i];
       gboolean updated = FALSE;
       g_autoptr(GError) my_error = NULL;
-      g_autoptr(FlatpakRemoteState) state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_UPDATE, remote, NULL);
+      g_autoptr(FlatpakRemoteState) state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_UPDATE, remote, NULL, NULL);
 
       g_debug ("Looking for remote metadata updates for %s", remote);
       if (!flatpak_dir_update_remote_configuration (priv->dir, remote, state, &updated, cancellable, &my_error))
@@ -2854,7 +2863,7 @@ flatpak_transaction_add_auto_install (FlatpakTransaction *self,
           deploy = flatpak_dir_get_if_deployed (priv->dir, auto_install_ref, NULL, cancellable);
           if (deploy == NULL)
             {
-              g_autoptr(FlatpakRemoteState) state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_UPDATE, remote, NULL);
+              g_autoptr(FlatpakRemoteState) state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_UPDATE, remote, NULL, NULL);
 
               if (state != NULL &&
                   flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (auto_install_ref), NULL, NULL, NULL, NULL, NULL))
@@ -3176,7 +3185,7 @@ resolve_ops (FlatpakTransaction *self,
             priv->max_op = MAX (priv->max_op, RUNTIME_INSTALL);
         }
 
-      state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, error);
+      state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, NULL, error);
       if (state == NULL)
         return FALSE;
 
@@ -4750,7 +4759,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
           res = FALSE;
         }
       else if (op->kind != FLATPAK_TRANSACTION_OPERATION_UNINSTALL &&
-               (state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, &local_error)) == NULL)
+               (state = flatpak_transaction_ensure_remote_state (self, op->kind, op->remote, NULL, &local_error)) == NULL)
         {
           res = FALSE;
         }

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2285,6 +2285,7 @@ flatpak_parse_repofile (const char   *remote_name,
       decoded = g_base64_decode (gpg_key, &decoded_len);
       if (decoded_len < 10) /* Check some minimal size so we don't get crap */
         {
+          g_free (decoded);
           flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid gpg key"));
           return NULL;
         }

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5084,7 +5084,7 @@ validate_component (FlatpakXml *component,
     }
 
   while ((bundle = flatpak_xml_find (component, "bundle", &prev)) != NULL)
-    flatpak_xml_free (flatpak_xml_unlink (component, bundle));
+    flatpak_xml_free (flatpak_xml_unlink (bundle, prev));
 
   bundle = flatpak_xml_new ("bundle");
   bundle->attribute_names = g_new0 (char *, 2 * 4);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2304,6 +2304,8 @@ flatpak_parse_repofile (const char   *remote_name,
   if (collection_id == NULL)
     collection_id = g_key_file_get_string (keyfile, source_group,
                                            FLATPAK_REPO_COLLECTION_ID_KEY, NULL);
+  if (collection_id != NULL && *collection_id == '\0')
+    g_clear_pointer (&collection_id, g_free);
   if (collection_id != NULL)
     {
       if (gpg_key == NULL)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2299,7 +2299,9 @@ flatpak_parse_repofile (const char   *remote_name,
 
   collection_id = g_key_file_get_string (keyfile, source_group,
                                          FLATPAK_REPO_DEPLOY_COLLECTION_ID_KEY, NULL);
-  if (collection_id == NULL || *collection_id == '\0')
+  if (collection_id != NULL && *collection_id == '\0')
+    g_clear_pointer (&collection_id, g_free);
+  if (collection_id == NULL)
     collection_id = g_key_file_get_string (keyfile, source_group,
                                            FLATPAK_REPO_COLLECTION_ID_KEY, NULL);
   if (collection_id != NULL)

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -759,7 +759,7 @@ handle_spawn (PortalFlatpak         *object,
   const gint *fds = NULL;
   gint fds_len = 0;
   g_autofree FdMapEntry *fd_map = NULL;
-  gchar **env;
+  g_auto(GStrv) env = NULL;
   gint32 max_fd;
   GKeyFile *app_info;
   g_autoptr(GPtrArray) flatpak_argv = g_ptr_array_new_with_free_func (g_free);


### PR DESCRIPTION
The eos-updater unit tests (specifically, the tests which use flatpak) build various test flatpaks and install them using eos-updater-flatpak-installer in various situations. In order to test that there are no assumptions about the architecture in use, all these flatpaks and tests are done for a fictitious `arch` architecture (rather than, say `x86_64`). This used to work fine, but was broken in libflatpak by the transition to the new summary/subsummary architecture.

It was fixed upstream in https://github.com/flatpak/flatpak/issues/4252, but the fix is not in our version of flatpak (1.10.2). This backports it, plus some other fixes from master which look useful (all memory corruption/leak fixes). One of those leak fixes, 756b9eae, is needed to avoid cherry-pick conflicts when backporting https://github.com/flatpak/flatpak/pull/4256.

All of the cherry-picks completed without conflicts. The only complication is that this adds the new public symbol `FLATPAK_QUERY_FLAGS_ALL_ARCHES` but it’s an enum member so shouldn’t throw Debian’s symbol versioning.

Helps https://phabricator.endlessm.com/T31918, but is not directly related.