### PR TITLE
flatpak-dir: Clean up temp deploy dir on failure of flatpak_dir_deploy()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4489,6 +4489,66 @@ remove_old_appstream_tmpdirs (GFile *dir)
     }
 }
 
+/* Like the function above, this looks for old temporary directories created by
+ * previous versions of flatpak_dir_deploy().
+ * These are all directories starting with a dot. Such directories can be from a
+ * concurrent deploy, so we only remove directories older than a day to avoid
+ * races.
+*/
+static void
+remove_old_deploy_tmpdirs (GFile *dir)
+{
+  g_auto(GLnxDirFdIterator) dir_iter = { 0 };
+  time_t now = time (NULL);
+
+  if (!glnx_dirfd_iterator_init_at (AT_FDCWD, flatpak_file_get_path_cached (dir),
+                                    FALSE, &dir_iter, NULL))
+    return;
+
+  while (TRUE)
+    {
+      struct stat stbuf;
+      struct dirent *dent;
+      g_autoptr(GFile) tmp = NULL;
+
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dir_iter, &dent, NULL, NULL))
+        break;
+
+      if (dent == NULL)
+        break;
+
+      /* We ignore non-dotfiles and .timestamps as they are not tempfiles */
+      if (dent->d_name[0] != '.' ||
+          strcmp (dent->d_name, ".timestamp") == 0)
+        continue;
+
+      /* Check for right types and names. The format we’re looking for is:
+       * .[0-9a-f]{64}-[0-9A-Z]{6} */
+      if (dent->d_type == DT_DIR)
+        {
+          if (strlen (dent->d_name) != 72 ||
+              dent->d_name[65] != '-')
+            continue;
+        }
+      else
+        continue;
+
+      /* Check that the file is at least a day old to avoid races */
+      if (!glnx_fstatat (dir_iter.fd, dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW, NULL))
+        continue;
+
+      if (stbuf.st_mtime >= now ||
+          now - stbuf.st_mtime < SECS_PER_DAY)
+        continue;
+
+      tmp = g_file_get_child (dir, dent->d_name);
+
+      /* We ignore errors here, no need to worry anyone */
+      g_debug ("Deleting stale deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
+      (void)flatpak_rm_rf (tmp, NULL, NULL);
+    }
+}
+
 gboolean
 flatpak_dir_deploy_appstream (FlatpakDir   *self,
                               const char   *remote,
@@ -8369,6 +8429,12 @@ flatpak_dir_deploy (FlatpakDir          *self,
 
   if (!glnx_opendirat (AT_FDCWD, flatpak_file_get_path_cached (deploy_base), TRUE, &deploy_base_dfd, error))
     return FALSE;
+
+  /* There used to be a bug here where temporary files beneath @deploy_base were not removed,
+   * which could use quite a lot of space over time, so we check for these and remove them.
+   * We only do so for the current app to avoid every deploy operation iterating over
+   * every app directory and all their immediate descendents. That would be a bit much I/O. */
+  remove_old_deploy_tmpdirs (deploy_base);
 
   if (checksum_or_latest == NULL)
     {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8325,6 +8325,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *ref_id = NULL;
   g_autoptr(GFile) root = NULL;
   g_autoptr(GFile) deploy_base = NULL;
+  glnx_autofd int deploy_base_dfd = -1;
   g_autoptr(GFile) checkoutdir = NULL;
   g_autoptr(GFile) bindir = NULL;
   g_autofree char *checkoutdirpath = NULL;
@@ -8341,8 +8342,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
   OstreeRepoCheckoutAtOptions options = { 0, };
   const char *checksum;
   glnx_autofd int checkoutdir_dfd = -1;
-  g_autoptr(GFile) tmp_dir_template = NULL;
-  g_autofree char *tmp_dir_path = NULL;
   const char *xa_ref = NULL;
   g_autofree char *checkout_basename = NULL;
   gboolean created_extra_data = FALSE;
@@ -8352,6 +8351,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *metadata_contents = NULL;
   gsize metadata_size = 0;
   const char *flatpak;
+  g_auto(GLnxTmpDir) tmp_dir_handle = { 0, };
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -8365,6 +8365,9 @@ flatpak_dir_deploy (FlatpakDir          *self,
     return FALSE;
 
   deploy_base = flatpak_dir_get_deploy_dir (self, ref);
+
+  if (!glnx_opendirat (AT_FDCWD, flatpak_file_get_path_cached (deploy_base), TRUE, &deploy_base_dfd, error))
+    return FALSE;
 
   if (checksum_or_latest == NULL)
     {
@@ -8400,17 +8403,15 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                _("%s commit %s already installed"), flatpak_decomposed_get_ref (ref), checksum);
 
   g_autofree char *template = g_strdup_printf (".%s-XXXXXX", checkout_basename);
-  tmp_dir_template = g_file_get_child (deploy_base, template);
-  tmp_dir_path = g_file_get_path (tmp_dir_template);
 
-  if (g_mkdtemp_full (tmp_dir_path, 0755) == NULL)
+  if (!glnx_mkdtempat (deploy_base_dfd, template, 0755, &tmp_dir_handle, NULL))
     {
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            _("Can't create deploy directory"));
       return FALSE;
     }
 
-  checkoutdir = g_file_new_for_path (tmp_dir_path);
+  checkoutdir = g_file_get_child (deploy_base, tmp_dir_handle.path);
 
   if (!ostree_repo_read_commit (self->repo, checksum, &root, NULL, cancellable, error))
     {
@@ -8709,6 +8710,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
   if (!g_file_move (checkoutdir, real_checkoutdir, G_FILE_COPY_NO_FALLBACK_FOR_MOVE,
                     cancellable, NULL, NULL, error))
     return FALSE;
+
+  glnx_tmpdir_unset (&tmp_dir_handle);
 
   if (!flatpak_dir_set_active (self, ref, checkout_basename, cancellable, error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4484,6 +4484,7 @@ remove_old_appstream_tmpdirs (GFile *dir)
       tmp = g_file_get_child (dir, dent->d_name);
 
       /* We ignore errors here, no need to worry anyone */
+      g_debug ("Deleting stale appstream deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
       (void)flatpak_rm_rf (tmp, NULL, NULL);
     }
 }


### PR DESCRIPTION
This already happens for installs due to the cleanup path in `flatpak_dir_deploy_install()`, but it doesn’t happen for other calls to `flatpak_dir_deploy()`. Notably, during updates of already installed apps.

Specifically, this means that if an app update is cancelled due to being blocked by a parental controls policy, the temp deploy dir for that app (such as
`~/.local/share/flatpak/app/com.corp.App/x86_64/stable/.somehex-XXXXXX`) will be leaked. It will never be automatically cleaned up, as it’s not in `/var/tmp` either.

Fix that by using `glnx_mkdtempat()` to create a scoped temporary directory.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
(cherry picked from commit ce1829a703f2bc2e7868fd314ddefb63fbf7dce1) Upstream: https://github.com/flatpak/flatpak/pull/5158

https://phabricator.endlessm.com/T33923