### PR TITLE
debian: Add a tmpfiles.d snippet for deleting stale deploy tmpdirs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flatpak (1.12.7-1~bpo11+1endless2) master; urgency=medium
+
+  * Add tmpfiles.d snippet for deleting leaked deploy tmpdirs (T33923)
+
+ -- Philip Withnall <pwithnall@endlessos.org>  Tue, 01 Nov 2022 15:47:00 +0000
+
 flatpak (1.12.7-1~bpo11+1endless1) master; urgency=medium
 
   * Rebase on Debian Bullseye backports 1.12.7 release (T33491)

--- a/debian/flatpak.install
+++ b/debian/flatpak.install
@@ -11,6 +11,7 @@ usr/lib/systemd/user/flatpak-session-helper.service
 usr/lib/systemd/user/flatpak-sideload-usb-repo.path
 usr/lib/systemd/user/flatpak-sideload-usb-repo.service
 usr/lib/sysusers.d
+usr/lib/tmpfiles.d/flatpak-deploy-tmpdirs.conf
 usr/lib/tmpfiles.d/flatpak-sideload-repos.conf
 usr/libexec/flatpak-oci-authenticator
 usr/libexec/flatpak-portal


### PR DESCRIPTION
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33923