### PR TITLE
Revert "Checkout using the same mode of the repo"

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4683,8 +4683,7 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
 
   checkout_dir = g_file_new_for_path (tmpdir.path);
 
-  options.mode = (ostree_repo_get_mode (self->repo) == OSTREE_REPO_MODE_BARE) ?
-                 OSTREE_REPO_CHECKOUT_MODE_NONE : OSTREE_REPO_CHECKOUT_MODE_USER;
+  options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
   options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
   options.enable_fsync = FALSE; /* We checkout to a temp dir and sync before moving it in place */
   options.bareuseronly_dirs = TRUE; /* https://github.com/ostreedev/ostree/pull/927 */
@@ -8489,8 +8488,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   if (!flatpak_repo_collect_sizes (self->repo, root, &installed_size, NULL, cancellable, error))
     return FALSE;
 
-  options.mode = (ostree_repo_get_mode (self->repo) == OSTREE_REPO_MODE_BARE) ?
-                 OSTREE_REPO_CHECKOUT_MODE_NONE : OSTREE_REPO_CHECKOUT_MODE_USER;
+  options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
   options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
   options.enable_fsync = FALSE; /* We checkout to a temp dir and sync before moving it in place */
   options.bareuseronly_dirs = TRUE; /* https://github.com/ostreedev/ostree/pull/927 */


### PR DESCRIPTION
This reverts commit 883d9746cac3061b812f494f4ade728ce70e5334. All deployments have been changed to use a standard `bare-user-only` repository instead of a `bare` repository shared with the system OS repo. Now user mode checkouts can always be performed.

https://phabricator.endlessm.com/T34161