### PR TITLE
Fix fetching ostree metadata commit

### DIFF
--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -28,6 +28,10 @@ TEST_MATRIX= \
 	tests/test-summaries@system.wrap \
 	tests/test-subset@user.wrap \
 	tests/test-subset@system.wrap \
+	tests/test-ostree-metadata@user.wrap \
+	tests/test-ostree-metadata@system.wrap \
+	tests/test-ostree-metadata@user,oldsummary.wrap \
+	tests/test-ostree-metadata@system,oldsummary.wrap \
 	$(NULL)
 TEST_MATRIX_DIST= \
 	tests/test-basic.sh \
@@ -58,4 +62,5 @@ TEST_MATRIX_EXTRA_DIST= \
 	tests/test-update-portal.sh \
 	tests/test-summaries.sh \
 	tests/test-subset.sh \
+	tests/test-ostree-metadata.sh \
 	$(NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -283,6 +283,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-prune.sh \
 	tests/test-seccomp.sh \
 	tests/test-repair.sh \
+	tests/test-ostree-metadata.sh{{user+system}+{{user+system},oldsummary}} \
 	$(NULL)
 
 update-test-matrix:

--- a/tests/test-ostree-metadata.sh
+++ b/tests/test-ostree-metadata.sh
@@ -20,10 +20,11 @@
 set -euo pipefail
 
 USE_COLLECTIONS_IN_SERVER=yes
+USE_COLLECTIONS_IN_CLIENT=yes
 
 . $(dirname $0)/libtest.sh
 
-echo "1..1"
+echo "1..2"
 
 setup_repo
 
@@ -37,3 +38,10 @@ ${FLATPAK} repo --branches repos/test > branches
 assert_file_has_content branches "^ostree-metadata\s"
 
 ok "server repo"
+
+# Ensure a remote with a collection ID defined fetches the
+# ostree-metadata commit.
+${FLATPAK} ${U} remote-ls test-repo >/dev/null
+assert_has_file ${FL_DIR}/repo/refs/remotes/test-repo/ostree-metadata
+
+ok "client repo"

--- a/tests/test-ostree-metadata.sh
+++ b/tests/test-ostree-metadata.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Endless OS Foundation LLC
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+USE_COLLECTIONS_IN_SERVER=yes
+
+. $(dirname $0)/libtest.sh
+
+echo "1..1"
+
+setup_repo
+
+# Ensure the ostree-metadata commit has been created and that the
+# summary listing contains it.
+assert_has_file repos/test/summary
+assert_has_file repos/test/refs/heads/ostree-metadata
+ostree --repo=repos/test summary --view > summary-view
+assert_file_has_content summary-view "(${COLLECTION_ID}, ostree-metadata)"
+${FLATPAK} repo --branches repos/test > branches
+assert_file_has_content branches "^ostree-metadata\s"
+
+ok "server repo"

--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -32,11 +32,6 @@ echo "1..9"
 #Regular repo
 setup_repo
 
-# Endless-specific: bring back the ostree-metadata ref and then
-# regenerate the appropriate flatpak repo metadata.
-ostree --repo=repos/test summary --update ${FL_GPGARGS}
-update_repo
-
 # Ensure we have the full locale extension:
 ${FLATPAK} ${U} config  --set languages "*"
 


### PR DESCRIPTION
The aim here is to fix regressions in 438e8115 so that flatpak continues to fetch the `ostree-metadata` commit when the remote has a collection ID. Unfortunately, the current test in `test-sideload.sh` is skipped in our build configurations since it requires `bwrap` to work. This contains a new test script, `test-ostree-metadata.sh` that doesn't require any special privileges.

In order to perform the test, the `ostree-metadata` commit needs to be created and included in the summary. Previously this was done with a hack to run `ostree summary -u` before `flatpak build-update-repo`. That would still work for the compat ostree format summary, but it does not affect the new flatpak indexed summaries. This would also be used in our infrastructure when it updates to a newer flatpak. See https://phabricator.endlessm.com/T33445.

I'm marking this as a draft as I don't know if we want to bother with this anymore. The reason to support this is to allow USB's created with current flatpak to be consumed by flatpak on EOS <= 3.8. If that's not desired, then we can revert 438e8115 and move on with our lives.

https://phabricator.endlessm.com/T34320