### PR TITLE
flatpak-run: Unset GDK_BACKEND

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1856,6 +1856,7 @@ static const ExportData default_exports[] = {
   {"GST_PTP_HELPER", NULL},
   {"GST_PTP_HELPER_1_0", NULL},
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
+  {"GDK_BACKEND", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -89,6 +89,7 @@
             <member>PERLLIB</member>
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
+            <member>GDK_BACKEND</member>
         </simplelist>
         <para>
             Flatpak also overrides the XDG environment variables to point sandboxed applications


### PR DESCRIPTION
If the `GDK_BACKEND` environment variable is present and it's value does not match the Wayland and X11 socket configuration, then a GTK app will fail to run since it will only consider the display backend from the environment variable.

This should probably be extended to cover other display environment variables such as `QT_QPA_PLATFORM` for Qt and `SDL_VIDEODRIVER` for SDL. However, I've only tested this with GTK applications.

(cherry picked from commit cc122e297235d68301f2c4c466bed997db05937c)

https://phabricator.endlessm.com/T34456