### PR TITLE
Only load fontconfig cache from /usr/lib/fontconfig/cache

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,6 +54,7 @@ override_dh_auto_configure:
 		--with-system-dbus-proxy=xdg-dbus-proxy \
 		--with-systemdsystemunitdir=/lib/systemd/system \
 		--with-system-helper-user=_flatpak \
+		--with-system-font-cache-dirs=/usr/lib/fontconfig/cache \
 		$(configure_options)
 
 override_dh_install:


### PR DESCRIPTION
Our fontconfig package has been changed to generate the system font cache in `/usr/lib/fontconfig/cache` so that it can be shipped in the OS commit. By default, flatpak considers that only if `/var/cache/fontconfig` doesn't exist. Normally that's the case, but some systems may have a stray directory that prevents using system fonts in applications. Change the setting so that only the system cache in `/usr` is considered.

https://phabricator.endlessm.com/T34305