### PR TITLE
transaction: Ignore uninstall operations for no deploy

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2112,6 +2112,13 @@ add_related (FlatpakTransaction          *self,
           if (!rel->delete)
             continue;
 
+          if (priv->no_deploy)
+            {
+              g_info ("Skipping uninstallation of %s for no deploy transaction",
+                      flatpak_decomposed_get_ref (rel->ref));
+              continue;
+            }
+
           related_op = flatpak_transaction_add_op (self, rel->remote, rel->ref,
                                                    NULL, NULL, NULL, NULL,
                                                    FLATPAK_TRANSACTION_OPERATION_UNINSTALL,
@@ -2512,6 +2519,13 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
     }
   else if (kind == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
     {
+      /* Skip uninstall for no deploy transactions. */
+      if (priv->no_deploy)
+        {
+          g_info ("Skipping uninstallation of %s for no deploy transaction", pref);
+          return TRUE;
+        }
+
       if (!dir_ref_is_installed (priv->dir, ref, &origin, NULL))
         return flatpak_fail_error (error, FLATPAK_ERROR_NOT_INSTALLED,
                                    _("%s not installed"), pref);
@@ -2747,7 +2761,8 @@ flatpak_transaction_add_update (FlatpakTransaction *self,
  * @ref: the ref
  * @error: return location for a #GError
  *
- * Adds uninstalling the given ref to this transaction.
+ * Adds uninstalling the given ref to this transaction. If the transaction is
+ * set to not deploy updates, the request is ignored.
  *
  * Returns: %TRUE on success; %FALSE with @error set on failure.
  */
@@ -4621,6 +4636,13 @@ add_uninstall_unused_ops (FlatpakTransaction  *self,
       origin = flatpak_dir_get_origin (priv->dir, unused_ref, NULL, NULL);
       if (origin)
         {
+          if (priv->no_deploy)
+            {
+              g_info ("Skipping uninstallation of %s for no deploy transaction",
+                      unused_ref_str);
+              continue;
+            }
+
           /* These get added last and have no dependencies, so will run last */
           uninstall_op = flatpak_transaction_add_op (self, origin, unused_ref,
                                                      NULL, NULL, NULL, NULL,

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -404,6 +404,13 @@ ${FLATPAK} build-commit-from --no-update-summary --end-of-life-rebase=org.test.H
 GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test-rebase org.test.NewHello master "${REBASE_COLLECTION_ID}" "NEW" > /dev/null
 update_repo test-rebase
 
+# First do a --no-deploy update and check the old version is still installed
+${FLATPAK} ${U} update -y --no-deploy org.test.Hello >&2
+
+assert_has_dir $HOME/.var/app/org.test.Hello
+assert_has_file $HOME/.var/app/org.test.Hello/data/a-file
+assert_not_has_dir $HOME/.var/app/org.test.NewHello
+
 ${FLATPAK} ${U} update -y org.test.Hello
 
 # Make sure we got the new version installed
@@ -456,6 +463,12 @@ assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
 make_updated_runtime "" "" "mainline" ""
 make_updated_app "" "" "" "UPDATED99" "" "mainline"
 
+# First update with --no-deploy and check the old runtime is still installed
+${FLATPAK} ${U} update -y --no-deploy org.test.Hello >&2
+
+assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
+assert_not_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/mainline/active/files
+
 ${FLATPAK} ${U} update -y org.test.Hello
 
 # The previous runtime should have been removed during the update
@@ -483,7 +496,11 @@ ${FLATPAK} ${U} update -y org.test.Platform
 ${FLATPAK} ${U} info org.test.Platform > info-log
 assert_file_has_content info-log "End-of-life: Reason4"
 
-# Now that the runtime is EOL and unused it should be uninstalled by the update command
+# Now that the runtime is EOL and unused it should be uninstalled by the
+# update command. Check first that it's not uninstalled with --no-deploy.
+${FLATPAK} ${U} update -y --no-deploy >&2
+assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
+
 ${FLATPAK} ${U} update -y
 assert_not_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3253,6 +3253,28 @@ test_transaction_install_uninstall (void)
 
   g_clear_object (&transaction);
 
+  /* uninstall org.test.Hello with no_deploy set to TRUE. This should be a
+   * no-op.
+   */
+  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (transaction);
+
+  flatpak_transaction_set_no_deploy (transaction, TRUE);
+  g_assert_true (flatpak_transaction_get_no_deploy (transaction));
+
+  res = flatpak_transaction_add_uninstall (transaction, app, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  g_assert_true (flatpak_transaction_is_empty (transaction));
+
+  list = flatpak_transaction_get_operations (transaction);
+  g_assert_cmpint (g_list_length (list), ==, 0);
+  g_list_free (list);
+
+  g_clear_object (&transaction);
+
   /* uninstall org.test.Hello, we expect org.test.Hello.Locale to be
    * removed with it, but org.test.Platform to stay
    */


### PR DESCRIPTION
If `no_deploy` has been set to `TRUE` in a transaction, then the intention is that no changes will be made to the installed flatpaks. Currently that's not the case for explicitly or implicitly added uninstall operations. That's particularly bad for eol-rebase flatpaks since they old version will be automatically removed without the new version being installed. To address this, prevent uninstall operations from being added for no deploy transactions.

Closes: #5172

https://phabricator.endlessm.com/T34071

This is taken from flatpak/flatpak#5289. It's almost a clean cherry pick of the one commit, but there have been some minor changes in `tests/test-repo.sh` that caused some conflicts.