### PR TITLE
1.12.8 Debian packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flatpak (1.12.8-0endless1) master; urgency=medium
+
+  * New upstream stable release (T34619)
+
+ -- Dan Nicholson <dbn@endlessos.org>  Thu, 23 Mar 2023 17:08:58 -0600
+
 flatpak (1.12.7-1~bpo11+1endless1) master; urgency=medium
 
   * Rebase on Debian Bullseye backports 1.12.7 release (T33491)


### PR DESCRIPTION
Debian is now backporting 1.14 to bullseye, so there was no upstream packaging to include. There were also no actual packaging changes, so it's just the new changelog entry.

https://phabricator.endlessm.com/T34619