### PR TITLE
Install /usr/lib/tmpfiles.d/flatpak.conf

### DIFF
--- a/debian/flatpak.install
+++ b/debian/flatpak.install
@@ -11,7 +11,7 @@ usr/lib/systemd/user/flatpak-session-helper.service
 usr/lib/systemd/user/flatpak-sideload-usb-repo.path
 usr/lib/systemd/user/flatpak-sideload-usb-repo.service
 usr/lib/sysusers.d
-usr/lib/tmpfiles.d/flatpak-sideload-repos.conf
+usr/lib/tmpfiles.d
 usr/libexec/flatpak-oci-authenticator
 usr/libexec/flatpak-portal
 usr/libexec/flatpak-session-helper


### PR DESCRIPTION
This file is new upstream in 1.14.5.

I am listing the whole of usr/lib/tmpfiles.d here to follow the Debian package in Trixie.

https://phabricator.endlessm.com/T35258